### PR TITLE
fix: infra automation tutorial flow

### DIFF
--- a/flows/infrastructure-automation.yaml
+++ b/flows/infrastructure-automation.yaml
@@ -18,8 +18,8 @@ tasks:
     push: false # you can change this to true after adding credentials
     credentials:
       registry: https://index.docker.io/v1/
-      username: "{{ secret('DOCKERHUB_USERNAME') }}"
-      password: "{{ secret('DOCKERHUB_PASSWORD') }}"
+      username: "{{ kv('DOCKERHUB_USERNAME') }}"
+      password: "{{ kv('DOCKERHUB_PASSWORD') }}"
 
   - id: run_container
     type: io.kestra.plugin.docker.Run


### PR DESCRIPTION
secrets are evaluated at execution creation time; switching to KV allows us to avoid `PebbleException: Cannot find secret for key 'DOCKERHUB_USERNAME'`

@brian-mulier-p do we need to create a PR for both main and release branch? sorry that I'm not up to date with the merge/release process 😅 

