### PR TITLE
Improve SanityChecks CI & parsing

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -37,7 +37,7 @@ jobs:
               # mkdir -p "$target_dir"
               
               # Create a new YAML without the extend property and copy to "sanitychecks/flows/blueprints/
-              yq eval 'del(.extend)' "$flow" > "$target_file"
+              yq eval 'del(.extend) | .namespace = "sanitychecks"' "$flow" > "$target_file"
               echo "Copied $flow to $target_dir (without extend property)"
             fi
           done

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -35,27 +35,74 @@ jobs:
               git clone --filter=blob:none --sparse https://$GH_TOKEN:@github.com/kestra-io/$REPOSITORY.git
               cd $REPOSITORY
               git sparse-checkout init --cone
-              git sparse-checkout add $DESTINATION_PATH
+              
+              # First, get a list of all directories in the repository
+              git ls-tree -r --name-only HEAD | grep "/" > /tmp/all_paths
 
-              if test -d $DESTINATION_PATH; then
-                  COUNT=$(find $DESTINATION_PATH -type f | wc -l)
+              # Find potential paths containing DESTINATION_PATH (without trailing slash)
+              DESTINATION_NO_SLASH=${DESTINATION_PATH%/}
+              POSSIBLE_PATHS=$(grep "/${DESTINATION_NO_SLASH}/" /tmp/all_paths || true)
+              TOTAL_COUNT=0
+              FOUND_PATHS=""
+              
+              # If no paths found in git ls-tree, try the root path
+              if [ -z "$POSSIBLE_PATHS" ]; then
+                  git sparse-checkout add "$DESTINATION_PATH"
+                  if [ -d "$DESTINATION_PATH" ]; then
+                      COUNT=$(find "$DESTINATION_PATH" -type f | wc -l)
+                      TOTAL_COUNT=$((TOTAL_COUNT + COUNT))
+                      FOUND_PATHS="$DESTINATION_PATH"
+                      
+                      # Create results directory and copy files
+                      mkdir -p "../../results/$REPOSITORY"
+                      cp -R "$DESTINATION_PATH"/* "../../results/$REPOSITORY/"
+                  fi
               else
-                  COUNT=0
+                  # Create a temporary file to store unique directories
+                  echo "$POSSIBLE_PATHS" | while IFS= read -r PATH_ENTRY; do
+                      # Extract the base path up to sanity-checks
+                      BASE_PATH=$(echo "$PATH_ENTRY" | grep -o ".*${DESTINATION_NO_SLASH}")
+                      if [ ! -z "$BASE_PATH" ]; then
+                          echo "$BASE_PATH"
+                      fi
+                  done | sort -u > /tmp/unique_paths
+                  
+                  # Process each unique path
+                  while IFS= read -r UNIQUE_PATH; do
+                      git sparse-checkout add "$UNIQUE_PATH"
+                      
+                      if [ -d "$UNIQUE_PATH" ]; then
+                          COUNT=$(find "$UNIQUE_PATH" -type f | wc -l)
+                          if [ "$COUNT" -gt "0" ]; then
+                              TOTAL_COUNT=$((TOTAL_COUNT + COUNT))
+                              # Append to FOUND_PATHS with a separator
+                              if [ -z "$FOUND_PATHS" ]; then
+                                  FOUND_PATHS="$UNIQUE_PATH"
+                              else
+                                  FOUND_PATHS="$FOUND_PATHS, $UNIQUE_PATH"
+                              fi
+                              
+                              # Create results directory and copy files
+                              mkdir -p "../../results/$REPOSITORY"
+                              cp -R "$UNIQUE_PATH"/* "../../results/$REPOSITORY/"
+                          fi
+                      fi
+                  done < /tmp/unique_paths
               fi
 
-              if [ "$COUNT" -gt "0" ]; then
-                  mkdir -p ../../results/$REPOSITORY
-                  cp -R $DESTINATION_PATH* ../../results/$REPOSITORY
-                  echo -e "\x1B[32m-> $REPOSITORY - $COUNT found \x1B[0m"
+              if [ "$TOTAL_COUNT" -gt "0" ]; then
+                  echo -e "\x1B[32m-> $REPOSITORY - $TOTAL_COUNT found in paths: $FOUND_PATHS \x1B[0m"
               else
                   echo -e "\x1B[31m-> $REPOSITORY - No sanity check found \x1B[0m"
+                  # Clean up empty results directory if nothing was found
+                  rm -rf "../../results/$REPOSITORY"
               fi
 
               cd ..
-              rm -rf $REPOSITORY
+              rm -rf "$REPOSITORY"
           done
 
-          rm -rf plugin-*
+          rm -rf plugin-* /tmp/all_paths /tmp/unique_paths
 
       - name: Prepare the commit
         env:

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -104,6 +104,38 @@ jobs:
 
           rm -rf plugin-* /tmp/all_paths /tmp/unique_paths
 
+      - name: Get all sanity check from Kestra core repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DESTINATION_PATH=kestra/core/src/test/resources/sanity-checks/
+          REPOSITORY=kestra
+          cd /tmp/repositories
+
+          git clone --filter=blob:none --sparse https://$GH_TOKEN:@github.com/kestra-io/$REPOSITORY.git
+          cd $REPOSITORY
+          git sparse-checkout init --cone
+          git sparse-checkout add $DESTINATION_PATH
+
+          if test -d $DESTINATION_PATH; then
+              COUNT=$(find $DESTINATION_PATH -type f | wc -l)
+          else
+              COUNT=0
+          fi
+
+          if [ "$COUNT" -gt "0" ]; then
+              mkdir -p ../../results/$REPOSITORY
+              cp -R $DESTINATION_PATH* ../../results/$REPOSITORY
+              echo -e "\x1B[32m-> $REPOSITORY - $COUNT found \x1B[0m"
+          else
+              echo -e "\x1B[31m-> $REPOSITORY - No sanity check found \x1B[0m"
+          fi
+
+          cd ..
+          rm -rf $REPOSITORY
+
+          rm -rf plugin-*
+
       - name: Prepare the commit
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -25,7 +25,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p sanitychecks/flows/blueprints
-          rm -rf sanitychecks/flows/blueprints
+          rm -rf sanitychecks/flows/blueprints/*.yaml
           for flow in $(find flows -name "*.yaml"); do
             # Check if the file has extend.demo=true
             is_demo=$(yq eval '.extend.demo // false' "$flow")

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -104,38 +104,6 @@ jobs:
 
           rm -rf plugin-* /tmp/all_paths /tmp/unique_paths
 
-      - name: Get all sanity check from Kestra core repository
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          DESTINATION_PATH=core/src/test/resources/sanity-checks/
-          REPOSITORY=kestra
-          cd /tmp/repositories
-
-          git clone --filter=blob:none --sparse https://$GH_TOKEN:@github.com/kestra-io/$REPOSITORY.git
-          cd $REPOSITORY
-          git sparse-checkout init --cone
-          git sparse-checkout add $DESTINATION_PATH
-
-          if test -d $DESTINATION_PATH; then
-              COUNT=$(find $DESTINATION_PATH -type f | wc -l)
-          else
-              COUNT=0
-          fi
-
-          if [ "$COUNT" -gt "0" ]; then
-              mkdir -p ../../results/$REPOSITORY
-              cp -R $DESTINATION_PATH* ../../results/$REPOSITORY
-              echo -e "\x1B[32m-> $REPOSITORY - $COUNT found \x1B[0m"
-          else
-              echo -e "\x1B[31m-> $REPOSITORY - No sanity check found \x1B[0m"
-          fi
-
-          cd ..
-          rm -rf $REPOSITORY
-
-          rm -rf plugin-*
-
       - name: Prepare the commit
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -25,7 +25,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           DESTINATION_PATH=src/test/resources/sanity-checks/
-          REPOSITORIES=$(gh repo list kestra-io -L 1000  --json  name | jq -r  .[].name | sort | grep "^plugin-")
+          REPOSITORIES=$(gh repo list kestra-io -L 1000 --json name | jq -r '.[].name' | sort | grep "^plugin-"; echo "kestra")
 
           mkdir -p /tmp/repositories /tmp/results
           cd /tmp/repositories
@@ -108,7 +108,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          DESTINATION_PATH=kestra/core/src/test/resources/sanity-checks/
+          DESTINATION_PATH=core/src/test/resources/sanity-checks/
           REPOSITORY=kestra
           cd /tmp/repositories
 

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -25,6 +25,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p sanitychecks/flows/blueprints
+          rm -rf sanitychecks/flows/blueprints
           for flow in $(find flows -name "*.yaml"); do
             # Check if the file has extend.demo=true
             is_demo=$(yq eval '.extend.demo // false' "$flow")

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -20,6 +20,27 @@ jobs:
         with:
           ref: main
 
+      - name: Get demo blueprint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p sanitychecks/flows/blueprints
+          for flow in $(find flows -name "*.yaml"); do
+            # Check if the file has extend.demo=true
+            is_demo=$(yq eval '.extend.demo // false' "$flow")
+            
+            if [ "$is_demo" = "true" ]; then
+              relative_path=${flow#flows/}
+              target_dir="sanitychecks/flows/blueprints/$(dirname "$relative_path")"
+              target_file="$target_dir/$(basename "$flow")"
+              
+              # mkdir -p "$target_dir"
+              
+              # Create a new YAML without the extend property and copy to "sanitychecks/flows/blueprints/
+              yq eval 'del(.extend)' "$flow" > "$target_file"
+              echo "Copied $flow to $target_dir (without extend property)"
+            fi
+          done
       - name: Get all sanity check from remote repository
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- fix parsing plugin repositories with sub-plugin definition (plugin-scripts for example
- fix parsing the kestra core repository and dedicated plugins
- parse the blueprint/flows folder looking for `extend.demo: true`, remove the `extend` props (so flow are valid), rename namespace to sanitychecks (as per the convention)

