### PR TITLE
feat(flow): update business process delay

### DIFF
--- a/flows/business-processes.yaml
+++ b/flows/business-processes.yaml
@@ -28,7 +28,7 @@ tasks:
 
   - id: wait_for_approval
     type: io.kestra.plugin.core.flow.Pause
-    timeout: "PT15M"
+    delay: "PT5M"
 
   - id: process_request
     type: io.kestra.plugin.core.http.Request


### PR DESCRIPTION
Move to delay because the flow was failing (problematic for sanitychecks) + move to 5 minutes