### PR TITLE
fix(blueprint): advanced scheduling was not working

### DIFF
--- a/flows/advanced-scheduling.yaml
+++ b/flows/advanced-scheduling.yaml
@@ -8,12 +8,11 @@ inputs:
   - id: date
     type: DATETIME
     required: false
-    defaults: 2023-12-24T14:00:00.000Z
+    defaults: 2023-12-22T14:00:00.000Z
 
 tasks:
   - id: check_if_business_date
     type: io.kestra.plugin.scripts.python.Commands
-    warningOnStdErr: false
     namespaceFiles:
       enabled: true
     commands:
@@ -54,8 +53,7 @@ extend:
     import sys
 
     from datetime import datetime
-    from workalendar.europe import France  # Import calendars for specific
-    countries
+    from workalendar.europe import France  # Import calendars for specific countries
     from workalendar.usa import UnitedStates  # Example for another country
 
     def is_business_day(date_str, country_calendar):


### PR DESCRIPTION
Multiple things were not working for the advanced scheduling blueprint :

1. `warningOnStdErr: false` is deprecated so it ended up in the following error and the flow couldn't be saved and executed:

![image](https://github.com/user-attachments/assets/4d10b813-4140-4889-b7aa-1a255b801eca)

2. The Python script was not working because the word "countries" was not in the comment above
3. 24/12/2023 is not a business day in the US so the default fallback made the flow fails by default. I changed it to 22/12/2023 which is a business day in the US