### PR TITLE
Add chaos testing flows

### DIFF
--- a/flows/chaos-testing.yaml
+++ b/flows/chaos-testing.yaml
@@ -1,0 +1,439 @@
+id: chaos-testing
+namespace: company.team
+
+variables:
+  network_chaos: ["network_latency", network_loss]
+  pod_chaos: ["Pod Kill"]
+  stress_chaos: [cpu_stress, memory_stress]
+  modes_needing_values: ["fixed", "fixed-percent", "random-max-percent"]
+
+inputs:
+  - id: github_repo_url
+    type: STRING
+    required: true
+    description: "GitHub repository URL (e.g. https://github.com/user/repo.git)"
+
+  - id: docker_hub_username
+    type: STRING
+    required: true
+    description: "Docker Hub username"
+
+  - id: docker_hub_password
+    type: STRING
+    required: true
+    description: "Docker Hub password"
+
+  - id: chaos_test
+    type: MULTISELECT
+    required: true
+    description: "Select the chaos tests to run on your deployment"
+    values:
+      - pod_kill
+      - network_latency
+      - network_loss
+      - cpu_stress
+      - memory_stress
+
+  - id: network_latency_ms
+    type: INT
+    required: false
+    description: "Network Latency in milliseconds"
+    defaults: 1000
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{inputs.chaos_test contains 'network_latency' }}"
+
+  - id: network_loss_percent
+    type: INT
+    required: false
+    description: "Network Loss percentage"
+    defaults: 25
+    max: 100
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{ inputs.chaos_test contains 'network_loss' }}"
+
+  - id: network_jitter
+    type: INT
+    required: false
+    description: "Jitter in Network Latency (latency ± value)"
+    defaults: 0
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{inputs.chaos_test contains 'network_latency' }}"
+
+  - id: correlation
+    type: INT
+    required: false
+    description: "Correlation: Indicates the correlation between the current latency/loss and the previous one. Range of value: [0, 100]"
+    defaults: 50
+    max: 100
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{inputs.chaos_test contains 'network_latency' or inputs.chaos_test contains 'network_loss'  }}"
+
+  # Stress Test Parameters
+  - id: memory_size
+    type: STRING
+    required: false
+    description: "Memory stress size (e.g., 128MB, 50%)"
+    defaults: "128MB"
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{ inputs.chaos_test contains 'memory_stress' }}"
+
+  - id: memory_workers
+    type: INT
+    required: false
+    description: "Number of memory stress workers"
+    defaults: 1
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{ inputs.chaos_test contains 'memory_stress' }}"
+
+  - id: cpu_workers
+    type: INT
+    required: false
+    description: "Number of CPU stress workers"
+    defaults: 1
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{ inputs.chaos_test contains 'cpu_stress' }}"
+
+  - id: cpu_load
+    type: INT
+    required: false
+    description: "CPU load percentage"
+    defaults: 80
+    dependsOn:
+      inputs:
+        - chaos_test
+      condition: "{{ inputs.chaos_test contains 'cpu_stress'  }}"
+
+  - id: tests_duration
+    type: INT
+    required: true
+    description: "Duration for all tests (in seconds)"
+    defaults: 30
+
+  - id: chaos_mode
+    type: SELECT
+    required: true
+    description: "Select mode for the tests"
+    values:
+      - one
+      - all
+      - fixed
+      - fixed-percent
+      - random-max-percent
+
+  - id: chaos_mode_value
+    type: STRING
+    required: false
+    defaults: 1
+    description: "Enter Chaos mode value.
+
+      Not applicable for **one** and **all**.
+
+      For **fixed**: no of pods.
+
+      For **fixed-percentage**: percentage of pods.
+
+      For **random-max-percent**: provide a max percentage value to be randomly selected"
+    dependsOn:
+      inputs:
+        - chaos_mode
+      condition: "{{ vars.modes_needing_values contains inputs.chaos_mode }}"
+
+  - id: threshold_error_rate
+    type: FLOAT
+    required: false
+    description: "Maximum acceptable error rate (0.05 = 5%)"
+    defaults: 0.05
+
+  - id: threshold_response_time
+    type: INT
+    required: false
+    description: "Maximum acceptable response time in ms"
+    defaults: 500
+
+  - id: app_url
+    type: STRING
+    required: false
+    description: "Application URL for load testing http://<node-ip>:3000"
+    defaults: http://10.104.238.108:3000/
+
+  - id: arrival_rate
+    type: INT
+    required: false
+    defaults: 10
+    description: "Number of virtual users increasing per second"
+
+  - id: max_v_users
+    type: INT
+    required: false
+    description: "Maximum number of virtual users (Optional)"
+
+tasks:
+  - id: wdir
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: clone_repository
+        type: io.kestra.plugin.git.Clone
+        url: "{{ inputs.github_repo_url }}"
+        depth: 1
+
+      - id: build_image
+        type: io.kestra.plugin.docker.Build
+        dockerfile: "{{ outputs.clone_repository.directory }}/Dockerfile"
+        tags:
+          - "{{inputs.docker_hub_username}}/test-microservice:latest"
+        pull: true
+        push: true
+        credentials:
+          registry: https://index.docker.io/v1/
+          username: "{{ inputs.docker_hub_username }}"
+          password: "{{ inputs.docker_hub_password }}"
+
+      - id: apply_deployment
+        type: io.kestra.plugin.kubernetes.kubectl.Apply
+        namespace: default
+        spec: |-
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sample-microservice
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                app: sample-microservice
+            template:
+              metadata:
+                labels:
+                  app: sample-microservice
+              spec:
+                containers:
+                  - name: sample-microservice
+                    image: "{{inputs.docker_hub_username}}/test-microservice:latest"
+                    imagePullPolicy: IfNotPresent
+                    ports:
+                      - containerPort: 3000
+                    readinessProbe:
+                      httpGet:
+                        path: /health
+                        port: 3000
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+
+      - id: apply_service
+        type: io.kestra.plugin.kubernetes.kubectl.Apply
+        namespace: default
+        spec: |-
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: sample-microservice
+          spec:
+            type: NodePort
+            ports:
+              - port: 3000
+                targetPort: 3000
+                nodePort: 30000
+            selector:
+              app: sample-microservice
+
+  # Wait for deployment to be ready
+  - id: wait_for_deployment
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: "PT30S"
+
+  # Run baseline test before chaos experiments
+  - id: baseline_artillery_test
+    type: io.kestra.plugin.docker.Run
+    containerImage: swymbnsl/artillery-runner:slim
+    inputFiles:
+      artillery-config.yml: |
+        config:
+          target: "http://sample-microservice:3000"
+          phases:
+            - duration: {{ inputs.tests_duration }}
+              arrivalRate: {{ inputs.arrival_rate }}
+          plugins:
+            metrics-by-endpoint: {}
+        scenarios:
+          - flow:
+              - get:
+                  url: "/"
+    credentials:
+      username: "{{ inputs.docker_hub_username }}"
+      password: "{{ inputs.docker_hub_password }}"
+    commands:
+      - artillery
+      - run
+      - artillery-config.yml
+      - --output
+      - baseline-results.json
+    outputFiles:
+      - baseline-results.json
+
+  - id: run_each_chaos_test
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{inputs.chaos_test}}"
+    tasks:
+      - id: call_general_chaos_sublflow
+        type: io.kestra.plugin.core.flow.Subflow
+        namespace: acert
+        flowId: general-chaos-test
+        inputs:
+          chaos_type: "{{ taskrun.value }}"
+          chaos_mode: "{{ inputs.chaos_mode }}"
+          chaos_mode_value: "{{ inputs.chaos_mode_value }}"
+          docker_hub_password: "{{ inputs.docker_hub_password }}"
+          docker_hub_username: "{{ inputs.docker_hub_username }}"
+          tests_duration: "{{ inputs.tests_duration  }}"
+          cpu_workers: "{{ inputs.cpu_workers }}"
+          cpu_load: "{{ inputs.cpu_load }}"
+          memory_workers: "{{ inputs.memory_workers }}"
+          memory_size: "{{ inputs.memory_size }}"
+          network_latency_ms: "{{ inputs.network_latency_ms }}"
+          network_jitter: "{{ inputs.network_jitter }}"
+          network_loss_percent: "{{ inputs.network_loss_percent }}"
+          correlation: "{{ inputs.correlation }}"
+          artillery_arrival_rate: "{{ inputs.arrival_rate }}"
+          app_url: "{{ inputs.app_url }}"
+
+  - id: analyze_chaos_results
+    type: io.kestra.plugin.scripts.node.Script
+    beforeCommands:
+      - npm i @kestra-io/libs
+
+    script: |
+      const fs = require('fs');
+      const path = require('path');
+      const Kestra = require('@kestra-io/libs');
+
+
+      const THRESHOLD_RESPONSE_TIME = {{ inputs.threshold_response_time }}
+      const THRESHOLD_ERROR_RATE = {{ inputs.threshold_error_rate}}
+
+      const outputsFile = {{ outputs.call_general_chaos_sublflow }}
+      console.log("OUTPUT FILE:", outputsFile)
+
+      let approved = true;
+      let failedTests = [];
+      const resultFiles = []
+      const testNames = []
+
+      for (const key in outputsFile) {
+        resultFiles.push(outputsFile[key].outputs.chaos_test_result)
+      }
+      for (const key in outputsFile) {
+        testNames.push(outputsFile[key].outputs.chaos_type_tested)
+      }
+
+
+      console.log('📊 A-CERT Chaos Test Results Analysis');
+      console.log('=====================================');
+
+      function safeGet(obj, pathArray, defaultValue = 0) {
+        return pathArray.reduce((acc, key) => (acc && acc[key] != null ? acc[key] : null), obj) ?? defaultValue;
+      }
+
+      for (const file of resultFiles) {
+
+        const testName = testNames[resultFiles.indexOf(file)]
+        const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+        const avgRT = safeGet(data, ['aggregate', 'summaries', 'http.response_time', 'mean']);
+        const p95RT = safeGet(data, ['aggregate', 'summaries', 'http.response_time', 'p95']);
+        const p99RT = safeGet(data, ['aggregate', 'summaries', 'http.response_time', 'p99']);
+
+        const timeoutErrors = safeGet(data, ['aggregate', 'counters', 'errors.ETIMEDOUT']);
+        const totalRequests = safeGet(data, ['aggregate', 'counters', 'http.requests']);
+        const successfulResponses = safeGet(data, ['aggregate', 'counters', 'http.responses']);
+        const failedUsers = safeGet(data, ['aggregate', 'counters', 'vusers.failed']);
+
+        const errorRate = totalRequests > 0 ? timeoutErrors / totalRequests : 0;
+        const successRate = totalRequests > 0 ? (successfulResponses * 100) / totalRequests : 0;
+
+        console.log(`📄 Test: ${testName}`);
+        console.log(`   ➤ Total Requests: ${totalRequests}`);
+        console.log(`   ➤ Successful Responses: ${successfulResponses}`);
+        console.log(`   ➤ Failed Users: ${failedUsers}`);
+        console.log(`   ➤ Timeout Errors: ${timeoutErrors}`);
+        console.log(`   ➤ Success Rate: ${successRate.toFixed(2)}%`);
+        console.log(`   ➤ Avg Response Time: ${avgRT} ms`);
+        console.log(`   ➤ P95 Response Time: ${p95RT} ms`);
+        console.log(`   ➤ P99 Response Time: ${p99RT} ms`);
+        console.log(`   ➤ Error Rate: ${errorRate.toFixed(6)}`);
+
+        const rtFailed = avgRT > THRESHOLD_RESPONSE_TIME;
+        const errorFailed = errorRate > THRESHOLD_ERROR_RATE;
+        const successFailed = successfulResponses === 0;
+        
+        if (rtFailed || errorFailed || successFailed) {
+          console.log(`   ❌ FAILED`);
+          if (rtFailed) {
+            console.log(`      - Response time exceeded: ${avgRT}ms > ${THRESHOLD_RESPONSE_TIME}ms`);
+          }
+          if (errorFailed) {
+            console.log(`      - Error rate exceeded: ${errorRate.toFixed(6)} > ${THRESHOLD_ERROR_RATE}`);
+          }
+          if (successFailed) {
+            console.log(`      - No successful responses received!`);
+          }
+          failedTests.push(testName);
+          approved = false;
+        } else {
+          console.log(`   ✅ PASSED`);
+        }
+
+        console.log('');
+      }
+
+      console.log('==============================');
+      console.log('📋 SUMMARY');
+      console.log('==============================');
+      console.log(`Thresholds:`);
+      console.log(`  - Max Response Time: ${THRESHOLD_RESPONSE_TIME}ms`);
+      console.log(`  - Max Error Rate: ${THRESHOLD_ERROR_RATE}`);
+      console.log('');
+
+      Kestra.outputs(
+        {
+          approved: approved,
+          total_tests: resultFiles.length,
+          failed_tests: failedTests,
+          passed_tests: resultFiles.length - failedTests.length,
+          summary: `Tests failed: ${failedTests.length} out of ${resultFiles.length}`
+        }
+        )
+
+      if (approved) {
+        console.log('🎉 All tests passed thresholds!');
+        console.log('::approved=true');
+        process.exit(0);
+      } else {
+        console.log('❌ Some tests failed!');
+        console.log('Failed tests:', failedTests.join(', '));
+        console.log('::approved=false');
+        process.exit(0);
+      }
+
+  - id: log_summary
+    type: io.kestra.plugin.core.log.Log
+    message:
+      - "🎯 Chaos Test Analysis Complete"
+      - "Approved: {{ outputs.analyze_chaos_results.vars.approved }}"
+      - "Total Tests: {{ outputs.analyze_chaos_results.vars.total_tests }}"
+      - "Passed Tests: {{ outputs.analyze_chaos_results.vars.passed_tests }}"
+      - "Failed Tests: {{ outputs.analyze_chaos_results.vars.failed_tests }}"
+      - "Summary: {{ outputs.analyze_chaos_results.vars.summary }}"

--- a/flows/general-chaos-test.yaml
+++ b/flows/general-chaos-test.yaml
@@ -1,0 +1,376 @@
+id: general-chaos-test
+namespace: company.team
+
+inputs:
+  - id: docker_hub_username
+    type: STRING
+    required: true
+    description: "Docker Hub username"
+
+  - id: docker_hub_password
+    type: STRING
+    required: true
+    description: "Docker Hub password"
+
+  - id: chaos_type
+    type: STRING
+    required: true
+    description: "Type of chaos to inject (cpu-stress, memory-stress, network-latency, network-loss, pod-kill)"
+  - id: chaos_mode
+    type: STRING
+    required: true
+    description: "Chaos mode (one, all, fixed, fixed-percent, random-max-percent)"
+  - id: chaos_mode_value
+    type: STRING
+    required: false
+    description: "Value for chaos mode when using fixed or percentage modes"
+    defaults: "1"
+  - id: tests_duration
+    type: STRING
+    required: true
+    description: "Duration for chaos experiment"
+  - id: cpu_workers
+    type: INT
+    required: true
+    description: "Number of CPU workers for stress test"
+  - id: cpu_load
+    type: INT
+    required: true
+    description: "CPU load percentage for stress test"
+  - id: memory_workers
+    type: INT
+    required: true
+    description: "Number of memory workers for stress test"
+  - id: memory_size
+    type: STRING
+    required: true
+    description: "Memory size for stress test"
+  - id: network_latency_ms
+    type: STRING
+    required: true
+    description: "Network latency for delay test"
+  - id: network_jitter
+    type: STRING
+    required: true
+    description: "Network jitter for delay test"
+  - id: network_loss_percent
+    type: STRING
+    required: true
+    description: "Network loss percentage"
+  - id: correlation
+    type: STRING
+    required: true
+    description: "Correlation percentage for network chaos"
+  - id: app_url
+    type: STRING
+    required: false
+    description: "Application URL for load testing"
+
+  - id: artillery_arrival_rate
+    type: INT
+    required: false
+    description: "Artillery arrival rate (requests per second)"
+    defaults: 10
+
+tasks:
+  - id: validate_chaos_type
+    type: io.kestra.plugin.core.flow.Switch
+    value: "{{ inputs.chaos_type }}"
+    cases:
+      cpu_stress:
+        - id: inject_cpu_stress
+          type: io.kestra.plugin.kubernetes.kubectl.Apply
+          namespace: default
+          spec: |-
+            apiVersion: chaos-mesh.org/v1alpha1
+            kind: StressChaos
+            metadata:
+              name: "cpu-stress-test"
+              namespace: default
+            spec:
+              mode: "{{ inputs.chaos_mode }}"
+              selector:
+                namespaces:
+                  - default
+                labelSelectors:
+                  "app": "sample-microservice"
+              duration: "{{ inputs.tests_duration }}s"
+              stressors:
+                cpu:
+                  workers: {{ inputs.cpu_workers }}
+                  load: {{ inputs.cpu_load }}
+
+        - id: wait_for_chaos_cpu
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: "PT5S"
+
+        - id: run_artillery_test_cpu
+          type: io.kestra.plugin.docker.Run
+          containerImage: swymbnsl/artillery-runner:slim
+          inputFiles:
+            artillery-config.yml: |
+              config:
+                target: "{{ inputs.app_url }}"
+                phases:
+                  - duration: {{ inputs.tests_duration }}
+                    arrivalRate: {{ inputs.artillery_arrival_rate }}
+                plugins:
+                  metrics-by-endpoint: {}
+              scenarios:
+                - flow:
+                    - get:
+                        url: "/"
+          credentials:
+            username: "{{ inputs.docker_hub_username }}"
+            password: "{{ inputs.docker_hub_password }}"
+          commands:
+            - artillery
+            - run
+            - artillery-config.yml
+            - --output
+            - test-results.json
+          outputFiles:
+            - test-results.json
+
+      memory_stress:
+        - id: inject_memory_stress
+          type: io.kestra.plugin.kubernetes.kubectl.Apply
+          namespace: default
+          spec: |-
+            apiVersion: chaos-mesh.org/v1alpha1
+            kind: StressChaos
+            metadata:
+              name: "memory-stress-test"
+              namespace: default
+            spec:
+              mode: "{{ inputs.chaos_mode }}"
+              selector:
+                namespaces:
+                  - default
+                labelSelectors:
+                  "app": "sample-microservice"
+              duration: "{{ inputs.tests_duration }}s"
+              stressors:
+                memory:
+                  workers: {{ inputs.memory_workers }}
+                  size: "{{ inputs.memory_size }}"
+
+        - id: wait_for_chaos_memory
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: "PT5S"
+
+        - id: run_artillery_test_memory
+          type: io.kestra.plugin.docker.Run
+          containerImage: swymbnsl/artillery-runner:slim
+          inputFiles:
+            artillery-config.yml: |
+              config:
+                target: "{{ inputs.app_url }}"
+                phases:
+                  - duration: {{ inputs.tests_duration }}
+                    arrivalRate: {{ inputs.artillery_arrival_rate }}
+                plugins:
+                  metrics-by-endpoint: {}
+              scenarios:
+                - flow:
+                    - get:
+                        url: "/"
+          credentials:
+            username: "{{ inputs.docker_hub_username }}"
+            password: "{{ inputs.docker_hub_password }}"
+          commands:
+            - artillery
+            - run
+            - artillery-config.yml
+            - --output
+            - test-results.json
+          outputFiles:
+            - test-results.json
+
+      network_latency:
+        - id: inject_network_latency
+          type: io.kestra.plugin.kubernetes.kubectl.Apply
+          namespace: default
+          spec: |-
+            apiVersion: chaos-mesh.org/v1alpha1
+            kind: NetworkChaos
+            metadata:
+              name: network-latency-test
+              namespace: default
+            spec:
+              action: delay
+              mode: "{{ inputs.chaos_mode }}"
+              value: "{{ inputs.chaos_mode_value }}"
+              selector:
+                namespaces:
+                  - default
+                labelSelectors:
+                  "app": "sample-microservice"
+              delay:
+                latency: "{{ inputs.network_latency_ms }}ms"
+                correlation: "{{ inputs.correlation }}"
+                jitter: "{{ inputs.network_jitter }}"
+              duration: "{{ inputs.tests_duration }}s"
+              direction: to
+
+        - id: wait_for_chaos_network_latency
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: "PT5S"
+
+        - id: run_artillery_test_network_latency
+          type: io.kestra.plugin.docker.Run
+          containerImage: swymbnsl/artillery-runner:slim
+          inputFiles:
+            artillery-config.yml: |
+              config:
+                target: "{{ inputs.app_url }}"
+                phases:
+                  - duration: {{ inputs.tests_duration }}
+                    arrivalRate: {{ inputs.artillery_arrival_rate }}
+                plugins:
+                  metrics-by-endpoint: {}
+              scenarios:
+                - flow:
+                    - get:
+                        url: "/"
+          credentials:
+            username: "{{ inputs.docker_hub_username }}"
+            password: "{{ inputs.docker_hub_password }}"
+          commands:
+            - artillery
+            - run
+            - artillery-config.yml
+            - --output
+            - test-results.json
+          outputFiles:
+            - test-results.json
+
+      network_loss:
+        - id: inject_network_loss
+          type: io.kestra.plugin.kubernetes.kubectl.Apply
+          namespace: default
+          spec: |-
+            apiVersion: chaos-mesh.org/v1alpha1
+            kind: NetworkChaos
+            metadata:
+              name: network-loss-test
+              namespace: default
+            spec:
+              action: loss
+              mode: "{{ inputs.chaos_mode }}"
+              value: "{{ inputs.chaos_mode_value }}"
+              selector:
+                namespaces:
+                  - default
+                labelSelectors:
+                  "app": "sample-microservice"
+              loss:
+                loss: "{{ inputs.network_loss_percent }}"
+                correlation: "{{ inputs.correlation }}"
+              duration: "{{ inputs.tests_duration }}s"
+              direction: to
+
+        - id: wait_for_chaos_network_loss
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: "PT5S"
+
+        - id: run_artillery_test_network_loss
+          type: io.kestra.plugin.docker.Run
+          containerImage: swymbnsl/artillery-runner:slim
+          inputFiles:
+            artillery-config.yml: |
+              config:
+                target: "{{ inputs.app_url }}"
+                phases:
+                  - duration: {{ inputs.tests_duration }}
+                    arrivalRate: {{ inputs.artillery_arrival_rate }}
+                plugins:
+                  metrics-by-endpoint: {}
+              scenarios:
+                - flow:
+                    - get:
+                        url: "/"
+          credentials:
+            username: "{{ inputs.docker_hub_username }}"
+            password: "{{ inputs.docker_hub_password }}"
+          commands:
+            - artillery
+            - run
+            - artillery-config.yml
+            - --output
+            - test-results.json
+          outputFiles:
+            - test-results.json
+
+      pod_kill:
+        - id: inject_pod_chaos
+          type: io.kestra.plugin.kubernetes.kubectl.Apply
+          namespace: default
+          spec: |-
+            apiVersion: chaos-mesh.org/v1alpha1
+            kind: PodChaos
+            metadata:
+              name: pod-kill-test
+              namespace: default
+            spec:
+              action: pod-kill
+              mode: "{{ inputs.chaos_mode }}"
+              value: "{{ inputs.chaos_mode_value }}"
+              selector:
+                namespaces:
+                  - default
+                labelSelectors:
+                  "app": "sample-microservice"
+              duration: "{{ inputs.tests_duration }}s"
+
+        - id: wait_for_chaos_pod_kill
+          type: io.kestra.plugin.core.flow.Sleep
+          duration: "PT5S"
+
+        - id: run_artillery_test_pod_kill
+          type: io.kestra.plugin.docker.Run
+          containerImage: swymbnsl/artillery-runner:slim
+          inputFiles:
+            artillery-config.yml: |
+              config:
+                target: "{{ inputs.app_url }}"
+                phases:
+                  - duration: {{ inputs.tests_duration }}
+                    arrivalRate: {{ inputs.artillery_arrival_rate }}
+                plugins:
+                  metrics-by-endpoint: {}
+              scenarios:
+                - flow:
+                    - get:
+                        url: "/"
+          credentials:
+            username: "{{ inputs.docker_hub_username }}"
+            password: "{{ inputs.docker_hub_password }}"
+          commands:
+            - artillery
+            - run
+            - artillery-config.yml
+            - --output
+            - test-results.json
+          outputFiles:
+            - test-results.json
+
+    defaults:
+      - id: shell_script_task
+        type: io.kestra.plugin.scripts.shell.Script
+        script: |
+          echo "Invalid chaos type: {{ inputs.chaos_type }}"
+          echo "Valid types: cpu-stress, memory-stress, network-latency, network-loss, pod-kill"
+          exit 1
+
+  - id: sleep
+    type: io.kestra.plugin.core.flow.Sleep
+    duration: "PT{{ inputs.tests_duration }}S"
+
+outputs:
+  - id: chaos_test_result
+    type: FILE
+    value: "{{ outputs['run_artillery_test_' + inputs.chaos_type]['outputFiles']['test-results.json'] }}"
+  - id: chaos_type_tested
+    type: STRING
+    value: "{{ inputs.chaos_type }}"


### PR DESCRIPTION
A main flow named 'chaos-testing.yaml' and a subflow named 'general-chaos-test.yaml' are added to perform chaos tests on microservices by deploying them on kubernetes pods

Allowed chaos tests are:
- pod-kill
- network-latency
- network-loss
- cppu-stress
- memory-stress

For more details, see https://github.com/swymbnsl/acert-kestra/