### PR TITLE
fix(git): dubious ownership on ai-summarize-last-months-git-commits

### DIFF
--- a/flows/ai-summarize-weekly-git-commits.yaml
+++ b/flows/ai-summarize-weekly-git-commits.yaml
@@ -29,6 +29,9 @@ tasks:
           type: io.kestra.plugin.scripts.runner.docker.Docker
         containerImage: bitnami/git:latest
         commands:
+          # 0. Set safe.directory for Git to avoid "dubious ownership" errors
+          - git config --global --add safe.directory "$(pwd)"
+
           # 1. Deepen clone if shallow
           - git fetch --unshallow origin {{ inputs.branch }} || true
 
@@ -36,8 +39,7 @@ tasks:
           - git fetch origin {{ inputs.branch }}
 
           # 3. Fetch commits from the last 7 days (weekly)
-          - git log origin/{{ inputs.branch }} --since="7 days ago" --pretty=format:"%h %ad %s"
-            --date=short > commits.txt
+          - git log origin/{{ inputs.branch }} --since="7 days ago" --pretty=format:"%h %ad %s" --date=short > commits.txt
 
           # 4. Show how many were found
           - echo "Fetched $(wc -l < commits.txt) commits from the last 7 days"


### PR DESCRIPTION
The `/tmp/*` directory appears to be dubious to git thus the error so we need to add it as a safe directory with the command I added in the flow.

The task now runs successfully:

<img width="3021" height="645" alt="image" src="https://github.com/user-attachments/assets/644d2c93-797c-4fdd-b4d2-4c99092e72da" />

fixes https://github.com/kestra-io/plugin-git/issues/158 