### PR TITLE
blueprints(apps): add connected flows

### DIFF
--- a/apps/ai-assistant.yaml
+++ b/apps/ai-assistant.yaml
@@ -89,9 +89,8 @@ extend:
     This App helps user research teams quickly generate insights, 
     without manually parsing full execution logs.
 
-    **Connected Flow**
+  flow: |
 
-    ```yaml
     id: ai_assistant
     namespace: company.team
 
@@ -184,8 +183,7 @@ extend:
             - id: log_response3
               type: io.kestra.plugin.core.log.Log
               message: "{{ json(outputs.discovery_prompt.body) }}"
-    ```
-    
+
   ee: true
   demo: false
   meta_description: |

--- a/apps/cloud-signup-form.yaml
+++ b/apps/cloud-signup-form.yaml
@@ -70,9 +70,8 @@ extend:
     This App pattern is suitable for lightweight, public data capture workflows that funnel submissions into
     Kestra executions for downstream processing and notifications.
 
-    **Connected Flow**
+  flow: |
 
-    ```yaml
     id: kestra_cloud_form
     namespace: company.team
 
@@ -96,7 +95,6 @@ extend:
       - id: save_in_db
         type: io.kestra.plugin.core.log.Log
         message: Signup received
-    ```
 
   tags:
     - Getting Started

--- a/apps/compute-resources-approval.yaml
+++ b/apps/compute-resources-approval.yaml
@@ -170,9 +170,8 @@ extend:
     This App improves governance by enforcing approval before resource allocation 
     while keeping the user experience streamlined through a single interface.
 
-    **Connected Flows**
+  flow: |
 
-    ```yaml
     id: request_resources
     namespace: company.team
 
@@ -281,7 +280,6 @@ extend:
       - id: catalog
         type: FILE
         value: "{{ outputs.get_service_catalog.uri }}"
-    ```
 
   tags:
     - Getting Started

--- a/apps/hello-world-app.yaml
+++ b/apps/hello-world-app.yaml
@@ -86,9 +86,8 @@ extend:
     This App is a good starting point for experimenting with executions, 
     and can be extended with additional states or UI blocks as needed.
 
-    **Connected Flow**
+  flow: |
 
-    ```yaml
     id: myflow
     namespace: company.team
 
@@ -101,7 +100,6 @@ extend:
       - id: hello
         type: io.kestra.plugin.core.log.Log
         message: Hello {{ inputs.user }}
-    ```
 
   ee: true
   demo: true

--- a/apps/past-execution.yaml
+++ b/apps/past-execution.yaml
@@ -46,9 +46,8 @@ extend:
 
     This pattern is useful for sharing generated reports, audit logs, or any reusable execution outputs without rerunning the flow.
 
-    **Connected Flow**
-    
-    ```yaml
+  flow: |
+
     id: get_data
     namespace: company.team
 
@@ -73,7 +72,6 @@ extend:
       - id: Data
         type: FILE
         value: "{{ outputs.extract.uri }}"
-    ```
   
   tags:
     - Getting Started

--- a/apps/request-data-form.yaml
+++ b/apps/request-data-form.yaml
@@ -101,7 +101,8 @@ extend:
 
         **Connected Flow**
     
-    ```yaml
+  flow: |
+
     id: get_data
     namespace: company.team
 
@@ -126,7 +127,6 @@ extend:
       - id: Data
         type: FILE
         value: "{{ outputs.extract.uri }}"
-    ```
 
   tags:
     - Getting Started

--- a/apps/vacation-approval-process.yaml
+++ b/apps/vacation-approval-process.yaml
@@ -132,9 +132,8 @@ extend:
     ensuring each request is approved before becoming official, 
     while providing employees with transparency and HR with governance.
 
-    **Connected Flows**
+  flow: |
 
-    ```yaml
     id: vacation
     namespace: company.team
 
@@ -180,7 +179,6 @@ extend:
         method: POST
         contentType: application/json
         body: "{{ inputs.request }}"
-    ```
 
   tags:
     - Getting Started


### PR DESCRIPTION
There actually isn't a great way to do this right now without jamming the flow into the description. It would be better to add a sub-property of extend for Apps blueprints or something like:

```yaml
extend:
  flowDependencies:
    company.team.my_flow: |
      id: my_flow
      namespace: company.team
      ...
   	company.other_flow: |
      ...
```