### PR TITLE
fix: S3 trigger flow blueprint

### DIFF
--- a/flows/s3-trigger-python.yaml
+++ b/flows/s3-trigger-python.yaml
@@ -29,15 +29,17 @@ triggers:
     region: "{{ vars.region }}"
     bucket: "{{ vars.bucket }}"
     filter: FILES
+    prefix: inbound/
     action: MOVE
     moveTo:
       key: archive/
+      bucket: "{{ vars.bucket }}"
     maxKeys: 1
 
 extend:
   title: "Detect New Files in S3 and process them in Python"
   description: |
-    This flow will be triggered whenever a new file is
+    This flow will be triggered whenever a new file prefixed `inbound/` is
     detected in the specified S3 bucket. It will download the file into the
     internal storage and move the S3 object to an `archive` folder (i.e. S3
     object prefix with the name `archive`). 


### PR DESCRIPTION
There were two issues:

* the `moveTo` requires the target bucket
* having no file prefix filter would create a loop