### PR TITLE
chore(sanitycheks): Change demo flag from true to false `io.kestra.plugin.core.trigger.Schedule`

### DIFF
--- a/flows/schedule-condition-publicholiday.yaml
+++ b/flows/schedule-condition-publicholiday.yaml
@@ -28,5 +28,5 @@ extend:
   tags:
     - Kestra
   ee: false
-  demo: true
+  demo: false
   meta_description: This flow executes on schedule trigger with PublicHoliday condition.


### PR DESCRIPTION
The `flows/schedule-condition-publicholiday.yaml` - `io.kestra.plugin.core.trigger.Schedule` flow is not working as intended (reported here: https://github.com/kestra-io/kestra/issues/11586), so stopping it from running inside the Sanity Checks till it gets sorted to make the sanity checks pass!