### PR TITLE
(flows): add github search

### DIFF
--- a/flows/github_search.yaml
+++ b/flows/github_search.yaml
@@ -1,0 +1,31 @@
+id: github_search_blueprint
+namespace: company.team
+
+tasks:
+  - id: top_kestra_repos
+    type: io.kestra.plugin.github.repositories.Search
+    query: "org:kestra-io"
+    visibility: PUBLIC
+    sort: STARS
+    order: DESC
+
+  - id: to_json
+    type: io.kestra.plugin.serdes.json.IonToJson
+    from: "{{ outputs.top_kestra_repos.uri }}"
+
+  - id: log_json
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ read(outputs.to_json.uri) | jq('.name') | first }}"
+
+extend:
+  title: Search GitHub org and log most starred repo
+  description: |
+    This flow searches GitHub repos within a given org and logs the repo name of the most starred repo within that org.
+    
+    This flow does not require any prerequisites or authentication.
+  tags:
+    - Getting Started
+    - Business
+  ee: false
+  demo: false
+  meta_description: Search GitHub repos within an org and log the most starred

--- a/flows/github_search.yaml
+++ b/flows/github_search.yaml
@@ -27,5 +27,5 @@ extend:
     - Getting Started
     - Business
   ee: false
-  demo: false
+  demo: true
   meta_description: Search GitHub repos within an org and log the most starred


### PR DESCRIPTION
Brings https://github.com/akeller/kestra-demos/blob/main/blueprints/github_search_blueprint.yaml into official Kestra blueprints 🚀 