### PR TITLE
blueprints(github-search): fix tags and formatting

### DIFF
--- a/flows/github-search.yaml
+++ b/flows/github-search.yaml
@@ -1,4 +1,4 @@
-id: github_search_blueprint
+id: github-search-blueprint
 namespace: company.team
 
 tasks:
@@ -24,7 +24,6 @@ extend:
     
     This flow does not require any prerequisites or authentication.
   tags:
-    - Getting Started
     - Business
   ee: false
   demo: true


### PR DESCRIPTION
Removing the `Getting Started` tag to prevent it showing up in new instances, as well as changing to `-` for consistency.