### PR TITLE
Add DataGen + MongoDB Blueprint

### DIFF
--- a/flows/datagen-mongodb.yaml
+++ b/flows/datagen-mongodb.yaml
@@ -1,0 +1,38 @@
+id: datagen-mongodb
+namespace: company.team
+
+tasks:
+  - id: datagen
+    type: io.kestra.plugin.datagen.core.Generate
+    batchSize: 100
+    store: true
+    generator:
+      type: io.kestra.plugin.datagen.generators.JsonObjectGenerator
+      locale: ["us", "US"]
+      value:
+        name: "#{name.fullName}"
+        email: "#{internet.emailAddress}"
+        age: 30
+        address:
+          city: "#{address.city}"
+          zip: "#{address.zipCode}"
+        skills: [ "#{job.keySkills}", "#{job.position}", "hardcoded" ]
+        ts: "{{ now() }}"
+
+  - id: send_to_mongodb
+    type: io.kestra.plugin.mongodb.Load
+    connection:
+      uri: "{{ secret('MONGO_POC') }}"
+    database: "{{ secret('DATABASE_NAME') }}"
+    collection: "{{ secret('COLLECTION_NAME') }}"
+    from: "{{ outputs.datagen.uri }}"
+
+extend:
+  title: Generate mock JSON data and send the file to MongoDB
+  description: Generate 100 records of mock people data with DataGen and send the JSON to MongoDB.
+  tags:
+    - Tool
+    - Database
+  ee: false
+  demo: false
+  meta_description: "This flow generates 100 records of mock people data in JSON with DataGen and loads it into a MongoDB collection."

--- a/flows/datagen-mongodb.yaml
+++ b/flows/datagen-mongodb.yaml
@@ -22,7 +22,7 @@ tasks:
   - id: send_to_mongodb
     type: io.kestra.plugin.mongodb.Load
     connection:
-      uri: "{{ secret('MONGO_POC') }}"
+      uri: "{{ secret('MONGO_URI') }}"
     database: "{{ secret('DATABASE_NAME') }}"
     collection: "{{ secret('COLLECTION_NAME') }}"
     from: "{{ outputs.datagen.uri }}"


### PR DESCRIPTION
DataGen was one of the plugins with no blueprint 😞  so I gave it a small and (hopefully) useful one that generates some JSON as mock data and loads it into MongoDB. I wasn't feeling super creative, but I thought this was a little more interesting than the DataGen examples just logging something out. 