### PR TITLE
add n8n based learning roadmap blueprint

### DIFF
--- a/flows/ai-learning-roadmap-n8n.yaml
+++ b/flows/ai-learning-roadmap-n8n.yaml
@@ -87,6 +87,6 @@ extend:
   tags:
     - AI
   ee: false
-  demo: true
+  demo: false
   meta_description: Generate a learning roadmap using Kestra and n8n.
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/blueprints/issues/162.

## What does this PR add?

This PR adds a new Blueprint to the catalog, demonstrating how to orchestrate
An AI-assisted learning roadmap using Kestra together with n8n (Gemini).

## What does the Blueprint show?

- Webhook-triggered orchestration.
- Integration with n8n for AI-driven planning.
- Validation of AI-generated JSON output.
- Generation of an Excel learning roadmap artifact.