### PR TITLE
(flows): swap slack payload for messageText

### DIFF
--- a/flows/weekly-confluence-recap.yaml
+++ b/flows/weekly-confluence-recap.yaml
@@ -89,18 +89,13 @@ tasks:
     - id: send_meetings_to_slack
       type: io.kestra.plugin.slack.SlackIncomingWebhook
       url: "{{ secret('SLACK_WEBHOOK') }}"
-      payload: |
-        {
-          "text": "You went to {{ kv('meetings_today') }} meetings and closed {{ kv('issues_today') }} PR(s) or issue(s)!"
-        }
+      messageText: "You went to {{ kv('meetings_today') }} meetings and closed {{ kv('issues_today') }} PR(s) or issue(s)!"
     else:
     - id: send_no_meetings_to_slack
       type: io.kestra.plugin.slack.SlackIncomingWebhook
       url: "{{ secret('SLACK_WEBHOOK') }}"
-      payload: |
-        {
-          "text": "No meetings or GitHub activity this week."
-        }
+      messageText: "No meetings or GitHub activity this week."
+      
 extend:
   title: Weekly recap of GitHub issues and Google Calendar meetings sent to Confluence
   description: |

--- a/flows/weekly-notion-recap.yaml
+++ b/flows/weekly-notion-recap.yaml
@@ -75,18 +75,12 @@ tasks:
     - id: send_meetings_to_slack
       type: io.kestra.plugin.slack.SlackIncomingWebhook
       url: "{{ secret('SLACK_WEBHOOK') }}"
-      payload: |
-        {
-          "text": "You went to {{ kv('meetings_today') }} meetings and closed {{ kv('issues_today') }} PR(s) or issue(s)!"
-        }
+      messageText: "You went to {{ kv('meetings_today') }} meetings and closed {{ kv('issues_today') }} PR(s) or issue(s)!"
     else:
     - id: send_no_meetings_to_slack
       type: io.kestra.plugin.slack.SlackIncomingWebhook
       url: "{{ secret('SLACK_WEBHOOK') }}"
-      payload: |
-        {
-          "text": "No meetings or GitHub activity this week."
-        }
+      messageText: "No meetings or GitHub activity this week."
 
 extend:
   title: Weekly recap of GitHub issues and Google Calendar meetings sent to Notion


### PR DESCRIPTION
`messageText` is friendly for Markdown, so let's swap it in for these two Blueprints.