### PR TITLE
(blueprint): Create redis-generate-mock-user-json.yaml

### DIFF
--- a/flows/redis-generate-mock-user-json.yaml
+++ b/flows/redis-generate-mock-user-json.yaml
@@ -1,0 +1,36 @@
+id: redis_generate_mock_user_json
+namespace: company.team
+description: Set a single mock user JSON in Redis
+
+tasks:
+  - id: datagen
+    type: io.kestra.plugin.datagen.core.Generate
+    generator:
+      type: io.kestra.plugin.datagen.generators.JsonObjectGenerator
+      locale: ["en", "US"]
+      value:
+        name: "#{name.fullName}"
+        email: "#{internet.emailAddress}"
+        skills: "#{job.keySkills}"
+  - id: set_redis
+    type: io.kestra.plugin.redis.json.Set
+    url: "{{ secret('REDIS_CLOUD') }}"
+    key: "{{ outputs.datagen.value['name'] }}"
+    value: |
+      {
+        "{{ outputs.datagen.value["email"] }}": "{{ outputs.datagen.value["skills"] }}"
+      }
+      
+extend:
+  shortDescription: "Set a single mock user JSON in Redis"
+  title: Set a single mock user JSON in Redis
+  description: |
+    Generate a single mock user JSON with a name, email, and skill, then set the name as the Redis key and the remaining data as the value. This lightweight task can be run multiple times to generate multiple keys.
+
+    Pre-requisites:
+    Must have a Redis Connection string.
+  tags:
+    - Data
+  ee: false
+  demo: false
+  meta_description: This blueprint will generate a single mock user JSON and store it in Redis.


### PR DESCRIPTION
Back with another generated data + database blueprint. Small, but hopefully interesting enough to add as a Blueprint. 