### PR TITLE
Add hint to README about tutorial namespace blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Blueprints are a curated, organized, and searchable catalog of ready-to-use exam
 
 Each Blueprint combines code and documentation and can be assigned several tags for organization and discoverability.
 
+## Tutorial namespace
+
+Some blueprints are packaged with Kestra and available in the `tutorial` namespace. This is a subset of the blueprints labeled "Getting Started".
+
 ## Contributing Tips
 
 ## Blueprint YAML contribution guidelines


### PR DESCRIPTION
Only a subset of the blueprints labeled "Getting Started" appear in the product, which I've mentioned in the README. If this is a miss and we want them all to appear, this needs to be investigated further since they seem to already be in the tutorial namespace.

<img width="948" height="299" alt="image" src="https://github.com/user-attachments/assets/d4a542e7-1c3d-4546-ae92-8aa2e6db1144" />

https://kestra.io/blueprints?page=1&size=24&tags=Getting+Started 