### PR TITLE
feat(blueprints): add Airflow, Dagster, and Zapier blueprints

### DIFF
--- a/flows/airflow-trigger-dag.yaml
+++ b/flows/airflow-trigger-dag.yaml
@@ -2,7 +2,7 @@ id: airflow-trigger-dag
 namespace: company.team
 
 inputs:
-  - name: dag_id
+  - id: dag_id
     type: STRING
     description: The Airflow DAG ID to trigger
     defaults: example_astronauts
@@ -52,7 +52,7 @@ extend:
       - `{{ outputs.trigger_dag.state }}`: Final state (success, failed, etc.).
 
   tags:
-    - Orchestration
+    - Data
   ee: false
   demo: false
   meta_description: Trigger an Apache Airflow DAG from Kestra and wait for completion.

--- a/flows/dagster-trigger-job.yaml
+++ b/flows/dagster-trigger-job.yaml
@@ -2,7 +2,7 @@ id: dagster-trigger-job
 namespace: company.team
 
 inputs:
-  - name: job_name
+  - id: job_name
     type: STRING
     description: The Dagster job name to trigger
     defaults: example_job
@@ -53,7 +53,7 @@ extend:
       - `{{ outputs.trigger_job.status }}`: Final status (SUCCESS, FAILURE, CANCELED).
 
   tags:
-    - Orchestration
+    - Data
   ee: false
   demo: false
   meta_description: Trigger a Dagster job from Kestra and wait for completion.

--- a/flows/zapier-trigger-zap.yaml
+++ b/flows/zapier-trigger-zap.yaml
@@ -2,11 +2,11 @@ id: zapier-trigger-zap
 namespace: company.team
 
 inputs:
-  - name: event_name
+  - id: event_name
     type: STRING
     description: Name of the event to send to Zapier
     defaults: workflow_completed
-  - name: message
+  - id: message
     type: STRING
     description: Custom message to include in the payload
     defaults: Hello from Kestra!
@@ -48,7 +48,7 @@ extend:
       - `{{ outputs.trigger_zap.attemptId }}`: Zapier attempt tracking ID.
 
   tags:
-    - Orchestration
+    - Business
   ee: false
   demo: false
   meta_description: Trigger a Zapier Zap from Kestra via a webhook.


### PR DESCRIPTION
## Summary
- **airflow-trigger-dag**: Triggers an Apache Airflow DAG via REST API with basic auth, passes Kestra metadata as DAG conf, and polls until completion.
- **dagster-trigger-job**: Triggers a Dagster job via GraphQL API with bearer token auth, passes Kestra metadata as run tags, and polls until terminal state.
- **zapier-trigger-zap**: Sends a JSON payload to a Zapier Catch Hook URL to trigger a Zap, enabling integration with thousands of Zapier-connected apps.

## Test plan
- [ ] Verify each YAML file is valid and renders correctly in the blueprint catalog
- [ ] Confirm `id` matches filename for all three blueprints
- [ ] Check that all secrets are documented in the description
- [ ] Validate task types match the actual plugin class names