### PR TITLE
feat: add 24 new blueprints (AI, ETL, monitoring, DevOps, integrations)

### DIFF
--- a/flows/ai-blog-post-generator.yaml
+++ b/flows/ai-blog-post-generator.yaml
@@ -160,6 +160,7 @@ tasks:
 
 extend:
   title: Generate AI Blog Posts in Your Brand Voice and Publish to WordPress as Draft
+  metaTitle: AI Blog Posts in Your Brand Voice
   shortDescription: "This blueprint fetches reference articles from your existing blog to extract brand voice, uses OpenAI GPT-4o to generate a full blog post on a new topic that matches your writing style, converts it to HTML, and saves it to WordPress as a draft — ready for human review and publishing."
   description: |
     This blueprint **fetches reference articles from your existing blog to extract brand voice**,
@@ -200,7 +201,4 @@ extend:
     - Content
   ee: false
   demo: false
-  meta_description: |
-    Automate brand-consistent blog creation with Kestra and OpenAI GPT-4o. Extracts writing style
-    from your existing articles, generates a full on-brand blog post in Markdown, converts to HTML,
-    and publishes to WordPress as a draft — with Slack notification for editorial review.
+  metaDescription: Automate brand-consistent blog creation with Kestra and OpenAI GPT-4o. Extracts your writing style, generates an on-brand blog post, and publishes to WordPress as a draft.

--- a/flows/ai-blog-post-generator.yaml
+++ b/flows/ai-blog-post-generator.yaml
@@ -198,7 +198,7 @@ extend:
     social media post generator that creates LinkedIn and Twitter variants from the same article.
   tags:
     - AI
-    - Content
+    - Business
   ee: false
   demo: false
   metaDescription: Automate brand-consistent blog creation with Kestra and OpenAI GPT-4o. Extracts your writing style, generates an on-brand blog post, and publishes to WordPress as a draft.

--- a/flows/ai-blog-post-generator.yaml
+++ b/flows/ai-blog-post-generator.yaml
@@ -1,0 +1,206 @@
+id: ai-blog-post-generator
+namespace: company.team
+
+inputs:
+  - id: post_topic
+    type: STRING
+    displayName: Blog post topic
+    description: The topic or title idea for the new blog post to generate
+  - id: brand_url
+    type: STRING
+    displayName: Brand RSS feed URL
+    description: RSS feed URL for your existing blog articles (used to extract brand voice)
+    defaults: "https://yourblog.com/feed"
+  - id: target_audience
+    type: STRING
+    displayName: Target audience
+    description: Target audience for tone calibration (e.g., software engineers, marketing managers)
+    defaults: "software engineers"
+  - id: cms_api_url
+    type: STRING
+    displayName: WordPress REST API base URL
+    description: WordPress REST API base URL (e.g., https://yourblog.com/wp-json/wp/v2)
+    defaults: "https://yourblog.com/wp-json/wp/v2"
+
+tasks:
+  - id: fetch_reference_articles
+    type: io.kestra.plugin.core.http.Request
+    uri: "{{ inputs.brand_url }}"
+    method: GET
+    headers:
+      Accept: "application/rss+xml, application/xml, text/xml, application/json"
+
+  - id: extract_brand_voice
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 800
+    jsonResponseSchema: |
+      {
+        "type": "object",
+        "properties": {
+          "tone": {"type": "string"},
+          "vocabulary": {"type": "string"},
+          "structure_pattern": {"type": "string"},
+          "example_opening": {"type": "string"},
+          "content_guidelines": {"type": "string"}
+        },
+        "required": ["tone", "vocabulary", "structure_pattern", "example_opening", "content_guidelines"]
+      }
+    messages:
+      - role: system
+        content: |
+          You are a brand voice analyst. Given sample blog content, extract the writing style and brand voice.
+          Analyze and return structured JSON with:
+          - tone: overall tone (e.g., "technical and direct", "conversational and encouraging")
+          - vocabulary: characteristic word choices, jargon level, formality
+          - structure_pattern: typical article structure (e.g., "problem → solution → example → CTA")
+          - example_opening: a sample opening sentence in this brand's style
+          - content_guidelines: key rules about what this brand does/avoids (bullet list as string)
+      - role: user
+        content: |
+          Analyze the brand voice from this blog content (first 3000 characters):
+          {{ outputs.fetch_reference_articles.body | truncate(3000) }}
+
+  - id: generate_blog_post
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 2000
+    messages:
+      - role: system
+        content: |
+          You are an expert content writer. Write a complete, publication-ready blog post that perfectly
+          matches the provided brand voice profile. The post should be in Markdown format with:
+          - A compelling H1 title
+          - An engaging introduction (2-3 paragraphs)
+          - 3-4 H2 sections with substantive content
+          - A conclusion with a clear takeaway
+
+          Target audience: {{ inputs.target_audience }}
+          Write for this audience specifically — calibrate depth, examples, and terminology accordingly.
+          Match the brand voice exactly. Do not add meta-commentary about the writing.
+      - role: user
+        content: |
+          Brand voice profile:
+          {{ outputs.extract_brand_voice.choices[0].message.content }}
+
+          Topic to write about: {{ inputs.post_topic }}
+
+          Write the full blog post now.
+
+  - id: prepare_wp_payload
+    type: io.kestra.plugin.scripts.python.Script
+    dependencies:
+      - markdown2
+    inputFiles:
+      post_content.md: "{{ outputs.generate_blog_post.choices[0].message.content }}"
+    script: |
+      import json
+      import re
+      import markdown2
+      from kestra import Kestra
+
+      with open("post_content.md") as f:
+          md_content = f.read()
+
+      # Extract H1 title from markdown
+      title_match = re.search(r'^#\s+(.+)$', md_content, re.MULTILINE)
+      title = title_match.group(1).strip() if title_match else "{{ inputs.post_topic }}"
+
+      # Remove the H1 from content (WordPress uses title field separately)
+      body_md = re.sub(r'^#\s+.+\n', '', md_content, count=1).strip()
+
+      # Convert Markdown to HTML
+      html_content = markdown2.markdown(body_md, extras=["fenced-code-blocks", "tables", "header-ids"])
+
+      # Generate excerpt from first paragraph
+      first_para = re.search(r'<p>(.+?)</p>', html_content, re.DOTALL)
+      excerpt = re.sub(r'<[^>]+>', '', first_para.group(1))[:300] if first_para else ""
+
+      # Count words
+      word_count = len(md_content.split())
+
+      payload = {
+          "title": title,
+          "content": html_content,
+          "status": "draft",
+          "excerpt": excerpt
+      }
+
+      Kestra.outputs({
+          "payload": json.dumps(payload),
+          "title": title,
+          "word_count": word_count,
+          "excerpt": excerpt
+      })
+
+  - id: publish_to_cms
+    type: io.kestra.plugin.core.http.Request
+    uri: "{{ inputs.cms_api_url }}/posts"
+    method: POST
+    contentType: "application/json"
+    headers:
+      Authorization: "Basic {{ secret('WP_AUTH_TOKEN') }}"
+    body: "{{ outputs.prepare_wp_payload.vars.payload }}"
+
+  - id: notify_slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    messageText: |
+      :pencil: *New Blog Draft Created*
+
+      *Topic:* {{ inputs.post_topic }}
+      *Title:* {{ outputs.prepare_wp_payload.vars.title }}
+      *Words:* {{ outputs.prepare_wp_payload.vars.word_count }}
+      *Status:* Draft saved to WordPress
+      *Audience:* {{ inputs.target_audience }}
+
+      _Review and publish at: {{ inputs.cms_api_url | replace('/wp-json/wp/v2', '/wp-admin/') }}_
+
+extend:
+  title: Generate AI Blog Posts in Your Brand Voice and Publish to WordPress as Draft
+  shortDescription: "This blueprint fetches reference articles from your existing blog to extract brand voice, uses OpenAI GPT-4o to generate a full blog post on a new topic that matches your writing style, converts it to HTML, and saves it to WordPress as a draft — ready for human review and publishing."
+  description: |
+    This blueprint **fetches reference articles from your existing blog to extract brand voice**,
+    uses **OpenAI GPT-4o** to generate a full blog post on a new topic that matches your writing
+    style exactly, converts the Markdown output to HTML, and saves it to **WordPress as a draft** —
+    ready for human review and one-click publishing.
+
+    It demonstrates how to:
+
+    1. Fetch your existing blog content via **RSS feed** to capture real published articles as style
+       references, giving the AI authentic brand voice material rather than generic instructions.
+    2. Use **GPT-4o structured JSON output** to systematically analyze tone, vocabulary patterns,
+       article structure, and content guidelines — building a precise brand voice profile.
+    3. Generate a **full Markdown blog post** (title, intro, 3-4 H2 sections, conclusion) using
+       the extracted voice profile and target audience as generation constraints.
+    4. Convert the Markdown output to **publication-ready HTML** using Python's `markdown2` library,
+       extract a clean excerpt, and count words for editorial metrics.
+    5. **POST the draft to WordPress** via the REST API using Basic authentication with an app
+       password, then notify the content team via **Slack** with the title, word count, and
+       review link.
+
+    This pattern is ideal for:
+      - **Content teams** that publish regularly and want AI-assisted drafts that sound on-brand,
+        not generic
+      - **Marketing automation** pipelines where new blog topics are triggered by keyword research,
+        competitor analysis, or campaign calendars
+      - **Solo bloggers and founders** who want to maintain publishing frequency without
+        proportional time investment
+      - **Agencies** managing multiple client blogs with distinct voices, running one flow per brand
+        with different `brand_url` inputs
+
+    The flow can be extended to add a human-approval gate using Kestra's Pause task before
+    publishing, integrate with SEO tools to auto-populate meta description and keywords, support
+    additional CMS targets (Ghost, Contentful, Strapi) via their REST APIs, or chain into a
+    social media post generator that creates LinkedIn and Twitter variants from the same article.
+  tags:
+    - AI
+    - Content
+  ee: false
+  demo: false
+  meta_description: |
+    Automate brand-consistent blog creation with Kestra and OpenAI GPT-4o. Extracts writing style
+    from your existing articles, generates a full on-brand blog post in Markdown, converts to HTML,
+    and publishes to WordPress as a draft — with Slack notification for editorial review.

--- a/flows/ai-document-data-extraction.yaml
+++ b/flows/ai-document-data-extraction.yaml
@@ -1,0 +1,253 @@
+id: ai-document-data-extraction
+namespace: company.team
+
+inputs:
+  - id: document_url
+    type: STRING
+    displayName: Document URL
+    description: Public URL to a PDF, HTML page, or text document to extract data from
+  - id: extraction_schema
+    type: STRING
+    displayName: Extraction schema (JSON)
+    description: |
+      JSON Schema defining the fields to extract. Example:
+      {"invoice_number": "string", "vendor_name": "string", "total_amount": "number", "line_items": "array of objects with description and amount"}
+    defaults: '{"invoice_number": "string", "vendor_name": "string", "invoice_date": "string", "total_amount": "number", "currency": "string", "line_items": "array of objects with description, quantity, unit_price, and total"}'
+  - id: document_type
+    type: SELECT
+    displayName: Document type
+    description: Type of document — used to calibrate the extraction prompt
+    values:
+      - invoice
+      - contract
+      - receipt
+      - report
+      - form
+      - other
+    defaults: "invoice"
+  - id: output_destination
+    type: SELECT
+    displayName: Output destination
+    description: Where to send the extracted structured data
+    values:
+      - postgres
+      - slack
+      - both
+    defaults: "both"
+
+tasks:
+  - id: download_document
+    type: io.kestra.plugin.core.http.Download
+    uri: "{{ inputs.document_url }}"
+    method: GET
+
+  - id: extract_text
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      document: "{{ outputs.download_document.uri }}"
+    dependencies:
+      - pypdf2
+      - beautifulsoup4
+      - requests
+    script: |
+      import os
+      import sys
+      import json
+      from kestra import Kestra
+
+      doc_path = "document"
+      content = ""
+
+      # Try to detect file type and extract text
+      with open(doc_path, "rb") as f:
+          header = f.read(8)
+
+      if header[:4] == b'%PDF':
+          # PDF extraction
+          try:
+              import PyPDF2
+              with open(doc_path, "rb") as f:
+                  reader = PyPDF2.PdfReader(f)
+                  pages = []
+                  for page in reader.pages:
+                      pages.append(page.extract_text() or "")
+              content = "\n".join(pages)
+          except Exception as e:
+              content = f"[PDF extraction error: {e}]"
+      else:
+          # Try HTML/text
+          try:
+              from bs4 import BeautifulSoup
+              with open(doc_path, "r", encoding="utf-8", errors="replace") as f:
+                  raw = f.read()
+              if raw.strip().startswith("<"):
+                  soup = BeautifulSoup(raw, "html.parser")
+                  # Remove scripts and styles
+                  for tag in soup(["script", "style", "nav", "footer"]):
+                      tag.decompose()
+                  content = soup.get_text(separator="\n", strip=True)
+              else:
+                  content = raw
+          except Exception as e:
+              content = f"[Text extraction error: {e}]"
+
+      # Truncate to avoid token limits (keep first 8000 chars)
+      content_truncated = content[:8000]
+      char_count = len(content)
+
+      Kestra.outputs({
+          "text_content": content_truncated,
+          "char_count": char_count,
+          "truncated": char_count > 8000
+      })
+
+  - id: extract_structured_data
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 1500
+    clientTimeout: 60
+    jsonResponseSchema: |
+      {
+        "type": "object",
+        "properties": {
+          "extracted_fields": {
+            "type": "object",
+            "description": "The extracted fields as defined in the extraction schema"
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Overall extraction confidence score"
+          },
+          "missing_fields": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of schema fields that could not be found in the document"
+          },
+          "extraction_notes": {
+            "type": "string",
+            "description": "Any caveats, ambiguities, or important observations about the extraction"
+          }
+        },
+        "required": ["extracted_fields", "confidence", "missing_fields"]
+      }
+    messages:
+      - role: system
+        content: |
+          You are a document data extraction specialist. Extract structured data from the provided
+          document text according to the given schema. Be precise — only extract values that are
+          explicitly present in the document. For missing fields, list them in `missing_fields`.
+          Return null for fields you cannot find rather than guessing.
+
+          Document type: {{ inputs.document_type }}
+          Extraction schema requested: {{ inputs.extraction_schema }}
+      - role: user
+        content: |
+          Extract the following data from this {{ inputs.document_type }} document:
+
+          Schema: {{ inputs.extraction_schema }}
+
+          Document text:
+          {{ outputs.extract_text.vars.text_content }}
+
+  - id: save_to_postgres
+    type: io.kestra.plugin.jdbc.postgresql.Queries
+    fetchType: NONE
+    runIf: "{{ inputs.output_destination == 'postgres' or inputs.output_destination == 'both' }}"
+    sql: |
+      CREATE TABLE IF NOT EXISTS document_extractions (
+          id SERIAL PRIMARY KEY,
+          document_url TEXT,
+          document_type TEXT,
+          extracted_data JSONB,
+          confidence NUMERIC,
+          missing_fields JSONB,
+          extraction_notes TEXT,
+          extracted_at TIMESTAMP DEFAULT NOW()
+      );
+
+      INSERT INTO document_extractions
+          (document_url, document_type, extracted_data, confidence, missing_fields, extraction_notes)
+      VALUES (
+          '{{ inputs.document_url }}',
+          '{{ inputs.document_type }}',
+          '{{ outputs.extract_structured_data.choices[0].message.content | json | jq(".extracted_fields") | first | json }}'::jsonb,
+          {{ outputs.extract_structured_data.choices[0].message.content | json | jq(".confidence") | first }},
+          '{{ outputs.extract_structured_data.choices[0].message.content | json | jq(".missing_fields") | first | json }}'::jsonb,
+          '{{ outputs.extract_structured_data.choices[0].message.content | json | jq(".extraction_notes // \"\"") | first | replace("'", "''") }}'
+      );
+
+  - id: notify_slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    runIf: "{{ inputs.output_destination == 'slack' or inputs.output_destination == 'both' }}"
+    messageText: |
+      :page_facing_up: *Document Extraction Complete*
+
+      *Type:* {{ inputs.document_type | title }}
+      *Source:* {{ inputs.document_url }}
+      *Confidence:* {{ outputs.extract_structured_data.choices[0].message.content | json | jq("(.confidence * 100 | floor | tostring) + \"%\"") | first }}
+      *Characters processed:* {{ outputs.extract_text.vars.char_count }}{{ outputs.extract_text.vars.truncated | ternary(' (truncated)', '') }}
+
+      *Extracted Data:*
+      ```{{ outputs.extract_structured_data.choices[0].message.content | json | jq(".extracted_fields") | first | json }}```
+
+      *Missing Fields:* {{ outputs.extract_structured_data.choices[0].message.content | json | jq(".missing_fields | if length == 0 then \"none\" else join(\", \") end") | first }}
+
+pluginDefaults:
+  - type: io.kestra.plugin.jdbc.postgresql.Queries
+    values:
+      url: "{{ secret('POSTGRES_URL') }}"
+      username: "{{ secret('POSTGRES_USER') }}"
+      password: "{{ secret('POSTGRES_PASSWORD') }}"
+
+extend:
+  title: AI Document Data Extraction — Parse PDFs and Web Pages into Structured JSON with OpenAI
+  shortDescription: "This blueprint downloads a document from any URL (PDF, HTML, or plain text), extracts readable text, uses OpenAI GPT-4o with a configurable JSON schema to pull out structured fields, and stores the results in PostgreSQL and/or Slack — turning unstructured documents into queryable data."
+  description: |
+    This blueprint **downloads a document from any URL** (PDF, HTML page, or plain text),
+    extracts readable text with format-aware parsing, uses **OpenAI GPT-4o with a configurable
+    extraction schema** to pull structured fields from the content, and stores the results in
+    **PostgreSQL and/or Slack** — turning unstructured documents into queryable, auditable data
+    without a dedicated document processing service.
+
+    It demonstrates how to:
+
+    1. Download documents from any public URL using the HTTP Download plugin, auto-detecting
+       the format (PDF, HTML, or plain text) for appropriate text extraction in Python using
+       **PyPDF2** and **BeautifulSoup4**, with graceful handling of encoding and parse errors.
+    2. Send the extracted text to **GPT-4o with a structured JSON extraction schema** defined
+       at runtime as a flow input — enabling flexible field extraction without code changes.
+       The model returns extracted fields, a confidence score, and a list of any missing fields.
+    3. **Conditionally persist results to PostgreSQL** using `runIf` expressions, storing
+       extracted data as a JSONB column alongside confidence scores and source metadata for
+       downstream querying and auditability.
+    4. **Post a structured Slack notification** with extracted data preview, confidence score,
+       missing fields, and source URL — enabling human review of low-confidence extractions
+       before downstream processing.
+
+    This pattern is ideal for:
+      - **Finance and operations teams** automating invoice, receipt, and contract data entry
+        into accounting systems without manual re-keying
+      - **Legal and compliance teams** extracting key clauses, dates, and parties from contracts
+        and regulatory filings at scale
+      - **Data engineering teams** building document ingestion pipelines for research reports,
+        government publications, or vendor data sheets
+      - **No-code automation builders** who need a reusable extraction flow where the output
+        schema is defined as a configuration parameter, not hardcoded
+
+    The flow can be extended to handle multi-page document batches via `ForEach`, add a
+    human-approval gate for extractions below a confidence threshold, integrate with cloud
+    storage (S3, GCS) to process documents from object storage buckets, or chain into a
+    downstream workflow that creates ERP records from extracted invoice data.
+  tags:
+    - AI
+    - Data
+  ee: false
+  demo: false
+  meta_description: |
+    Extract structured data from PDFs and web pages with Kestra and OpenAI GPT-4o. Downloads
+    documents from any URL, parses text with format detection, extracts configurable JSON fields
+    with confidence scoring, and stores results in PostgreSQL — fully automated document processing.

--- a/flows/ai-document-data-extraction.yaml
+++ b/flows/ai-document-data-extraction.yaml
@@ -205,6 +205,7 @@ pluginDefaults:
 
 extend:
   title: AI Document Data Extraction — Parse PDFs and Web Pages into Structured JSON with OpenAI
+  metaTitle: AI Document Data Extraction with OpenAI
   shortDescription: "This blueprint downloads a document from any URL (PDF, HTML, or plain text), extracts readable text, uses OpenAI GPT-4o with a configurable JSON schema to pull out structured fields, and stores the results in PostgreSQL and/or Slack — turning unstructured documents into queryable data."
   description: |
     This blueprint **downloads a document from any URL** (PDF, HTML page, or plain text),
@@ -247,7 +248,4 @@ extend:
     - Data
   ee: false
   demo: false
-  meta_description: |
-    Extract structured data from PDFs and web pages with Kestra and OpenAI GPT-4o. Downloads
-    documents from any URL, parses text with format detection, extracts configurable JSON fields
-    with confidence scoring, and stores results in PostgreSQL — fully automated document processing.
+  metaDescription: Extract structured data from PDFs and web pages with Kestra and OpenAI GPT-4o. Parses documents, extracts configurable JSON fields, and stores results in PostgreSQL.

--- a/flows/ai-github-pr-review.yaml
+++ b/flows/ai-github-pr-review.yaml
@@ -1,0 +1,141 @@
+id: ai-github-pr-review
+namespace: company.team
+
+inputs:
+  - id: repo_owner
+    type: STRING
+    displayName: Repository owner
+    description: GitHub username or organization owning the repository
+    defaults: "your-org"
+  - id: repo_name
+    type: STRING
+    displayName: Repository name
+    description: Name of the GitHub repository to monitor for new pull requests
+    defaults: "your-repo"
+  - id: pull_number
+    type: INT
+    displayName: Pull request number
+    description: The PR number to review
+    defaults: 1
+  - id: review_guidelines
+    type: STRING
+    displayName: Code review guidelines
+    description: Custom coding standards or best practices for the AI reviewer to apply
+    defaults: |
+      - Prefer clear variable names over abbreviations
+      - Functions should have a single responsibility
+      - Avoid deeply nested conditionals; prefer early returns
+      - All public APIs must have docstrings
+      - No hardcoded credentials or magic strings
+
+tasks:
+  - id: fetch_pr_diff
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://api.github.com/repos/{{ inputs.repo_owner }}/{{ inputs.repo_name }}/pulls/{{ inputs.pull_number }}/files"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('GITHUB_TOKEN') }}"
+      Accept: "application/vnd.github.v3+json"
+      X-GitHub-Api-Version: "2022-11-28"
+
+  - id: fetch_pr_metadata
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://api.github.com/repos/{{ inputs.repo_owner }}/{{ inputs.repo_name }}/pulls/{{ inputs.pull_number }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('GITHUB_TOKEN') }}"
+      Accept: "application/vnd.github.v3+json"
+      X-GitHub-Api-Version: "2022-11-28"
+
+  - id: generate_review
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 2000
+    messages:
+      - role: system
+        content: |
+          You are a senior software engineer performing a thorough code review.
+          Review the pull request diff below and provide actionable, constructive feedback.
+
+          Apply these coding guidelines:
+          {{ inputs.review_guidelines }}
+
+          Structure your review as:
+          ## Summary
+          Brief description of what this PR does.
+
+          ## Issues Found
+          List specific problems with file path and line context. Rate each as [CRITICAL], [MAJOR], or [MINOR].
+
+          ## Suggestions
+          Improvement suggestions that are not blocking.
+
+          ## Verdict
+          One of: ✅ APPROVED | ⚠️ APPROVED WITH SUGGESTIONS | ❌ CHANGES REQUESTED
+      - role: user
+        content: |
+          PR Title: {{ outputs.fetch_pr_metadata.body | json | jq('.title') | first }}
+          PR Description: {{ outputs.fetch_pr_metadata.body | json | jq('.body') | first }}
+
+          Changed files and diffs:
+          {{ outputs.fetch_pr_diff.body }}
+
+  - id: post_review_comment
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://api.github.com/repos/{{ inputs.repo_owner }}/{{ inputs.repo_name }}/issues/{{ inputs.pull_number }}/comments"
+    method: POST
+    contentType: "application/json"
+    headers:
+      Authorization: "Bearer {{ secret('GITHUB_TOKEN') }}"
+      Accept: "application/vnd.github.v3+json"
+      X-GitHub-Api-Version: "2022-11-28"
+    body: |
+      {
+        "body": "## 🤖 Automated AI Code Review\n\n{{ outputs.generate_review.choices[0].message.content | replace('\"', '\\\"') | replace('\n', '\\n') }}\n\n---\n_Reviewed by Kestra AI Code Review workflow_"
+      }
+
+triggers:
+  - id: github_webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "{{ secret('WEBHOOK_KEY') }}"
+
+extend:
+  title: Automatically Review GitHub Pull Requests with OpenAI GPT-4o and Post Comments
+  shortDescription: "This blueprint automates GitHub pull request code reviews by fetching diffs via the GitHub API, sending them to OpenAI GPT-4o with configurable coding guidelines, and posting the AI-generated review as a PR comment."
+  description: |
+    This blueprint **automates GitHub pull request code reviews** by fetching diffs via the
+    GitHub API, sending them to **OpenAI GPT-4o** with configurable coding guidelines, and
+    posting the AI-generated review directly as a **PR comment** — reducing review latency
+    and ensuring consistent standards enforcement.
+
+    It demonstrates how to:
+
+    1. Fetch the **PR diff and metadata** from the GitHub REST API, retrieving all changed
+       files and the PR title and description as context for the AI reviewer.
+    2. Send the diff and **custom coding guidelines** to **GPT-4o**, instructing it to
+       produce a structured review covering a summary, categorized issues (CRITICAL/MAJOR/MINOR),
+       suggestions, and a final verdict.
+    3. Post the AI-generated review as a **comment on the pull request** using the GitHub
+       Issues API, making it immediately visible to contributors.
+    4. Trigger the review on-demand via a **Webhook**, enabling integration with GitHub
+       Actions, external CI pipelines, or manual invocation from the Kestra UI.
+
+    This pattern is ideal for:
+      - **Engineering teams** that want consistent first-pass code review coverage across all PRs
+      - **Open source projects** with high PR volume where maintainer bandwidth is limited
+      - **Solo developers** who want an AI pair reviewer before requesting human review
+      - Teams that need **custom guidelines enforced** (security rules, style guides, API contracts)
+
+    The flow can be extended to fetch coding guidelines from a database or Notion page,
+    add a GitHub label (e.g., "AI-reviewed") after posting the comment, escalate
+    CRITICAL findings to a Slack channel, or trigger automatically from a GitHub webhook.
+  tags:
+    - AI
+    - DevOps
+  ee: false
+  demo: false
+  meta_description: |
+    Automatically review GitHub pull requests with OpenAI GPT-4o. Fetches diffs and metadata
+    from the GitHub API, generates a structured code review with configurable guidelines, and
+    posts the result as a PR comment — triggered via webhook.

--- a/flows/ai-github-pr-review.yaml
+++ b/flows/ai-github-pr-review.yaml
@@ -133,7 +133,7 @@ extend:
     CRITICAL findings to a Slack channel, or trigger automatically from a GitHub webhook.
   tags:
     - AI
-    - DevOps
+    - Infrastructure
   ee: false
   demo: false
   metaDescription: Automatically review GitHub pull requests with OpenAI GPT-4o. Fetches diffs, generates structured code reviews, and posts comments on the PR.

--- a/flows/ai-github-pr-review.yaml
+++ b/flows/ai-github-pr-review.yaml
@@ -102,6 +102,7 @@ triggers:
 
 extend:
   title: Automatically Review GitHub Pull Requests with OpenAI GPT-4o and Post Comments
+  metaTitle: Auto-Review GitHub PRs with OpenAI GPT-4o
   shortDescription: "This blueprint automates GitHub pull request code reviews by fetching diffs via the GitHub API, sending them to OpenAI GPT-4o with configurable coding guidelines, and posting the AI-generated review as a PR comment."
   description: |
     This blueprint **automates GitHub pull request code reviews** by fetching diffs via the
@@ -135,7 +136,4 @@ extend:
     - DevOps
   ee: false
   demo: false
-  meta_description: |
-    Automatically review GitHub pull requests with OpenAI GPT-4o. Fetches diffs and metadata
-    from the GitHub API, generates a structured code review with configurable guidelines, and
-    posts the result as a PR comment — triggered via webhook.
+  metaDescription: Automatically review GitHub pull requests with OpenAI GPT-4o. Fetches diffs, generates structured code reviews, and posts comments on the PR.

--- a/flows/ai-inventory-forecasting.yaml
+++ b/flows/ai-inventory-forecasting.yaml
@@ -190,6 +190,7 @@ triggers:
 
 extend:
   title: AI-Powered Inventory Demand Forecasting — Auto-Generate Purchase Orders with OpenAI
+  metaTitle: AI Inventory Demand Forecasting
   shortDescription: "This blueprint automates supply chain inventory management by fetching live warehouse and sales data every 6 hours, using OpenAI GPT-4o to forecast 7-day demand, generating purchase orders for items at risk of stockout, and logging everything to PostgreSQL with email notifications."
   description: |
     This blueprint **automates supply chain inventory management** by fetching live warehouse
@@ -228,7 +229,4 @@ extend:
     - Business
   ee: false
   demo: false
-  meta_description: |
-    Automate supply chain inventory management with Kestra and OpenAI GPT-4o. Fetches warehouse
-    and sales data every 6 hours, forecasts 7-day demand, generates purchase orders for items at
-    risk of stockout, and logs to PostgreSQL with email notifications.
+  metaDescription: Automate inventory management with Kestra and OpenAI GPT-4o. Forecasts 7-day demand, generates purchase orders for items at risk of stockout, and logs to PostgreSQL.

--- a/flows/ai-inventory-forecasting.yaml
+++ b/flows/ai-inventory-forecasting.yaml
@@ -1,0 +1,234 @@
+id: ai-inventory-forecasting
+namespace: company.team
+
+inputs:
+  - id: inventory_api_url
+    type: STRING
+    displayName: Inventory API URL
+    description: Endpoint returning current warehouse inventory levels as JSON
+    defaults: "https://api.yourwarehouse.com/v1/inventory"
+  - id: sales_api_url
+    type: STRING
+    displayName: Sales velocity API URL
+    description: Endpoint returning recent sales data as JSON
+    defaults: "https://api.yourwarehouse.com/v1/sales/velocity"
+  - id: supplier_api_url
+    type: STRING
+    displayName: Supplier PO API URL
+    description: Endpoint to POST new purchase orders to the supplier
+    defaults: "https://api.yoursupplier.com/v1/orders"
+  - id: erp_api_url
+    type: STRING
+    displayName: ERP API URL
+    description: ERP system endpoint for logging confirmed purchase orders
+    defaults: "https://erp.yourcompany.com/api/purchase-orders"
+
+tasks:
+  - id: fetch_data
+    type: io.kestra.plugin.core.flow.Parallel
+    tasks:
+      - id: fetch_inventory
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ inputs.inventory_api_url }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ secret('WAREHOUSE_API_TOKEN') }}"
+
+      - id: fetch_sales_velocity
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ inputs.sales_api_url }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ secret('WAREHOUSE_API_TOKEN') }}"
+
+  - id: ai_demand_forecast
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 1500
+    jsonResponseSchema: |
+      {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sku": {"type": "string"},
+                "current_stock": {"type": "number"},
+                "predicted_demand_7d": {"type": "number"},
+                "reorder_needed": {"type": "boolean"},
+                "recommended_quantity": {"type": "number"},
+                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                "reasoning": {"type": "string"}
+              },
+              "required": ["sku", "reorder_needed", "recommended_quantity", "confidence"]
+            }
+          }
+        },
+        "required": ["items"]
+      }
+    messages:
+      - role: system
+        content: |
+          You are a supply chain AI analyst. Given warehouse inventory levels and sales velocity data,
+          predict demand for the next 7 days and identify which items need reordering.
+
+          For each item, compute:
+          - Predicted demand over the next 7 days based on sales velocity trends
+          - Whether reordering is needed (stock will run out within 7 days)
+          - Recommended reorder quantity (2-week safety stock)
+          - Confidence score (0-1) in the forecast
+          - Brief reasoning
+
+          Return structured JSON only.
+      - role: user
+        content: |
+          Inventory data: {{ outputs.fetch_data.fetch_inventory.body }}
+          Sales velocity: {{ outputs.fetch_data.fetch_sales_velocity.body }}
+
+  - id: filter_and_create_orders
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      forecast.json: "{{ outputs.ai_demand_forecast.choices[0].message.content }}"
+    script: |
+      import json
+      from kestra import Kestra
+
+      with open("forecast.json") as f:
+          forecast = json.load(f)
+
+      items_needing_reorder = [
+          item for item in forecast.get("items", [])
+          if item.get("reorder_needed") and item.get("recommended_quantity", 0) > 0
+      ]
+
+      purchase_orders = []
+      for item in items_needing_reorder:
+          po = {
+              "sku": item["sku"],
+              "quantity": item["recommended_quantity"],
+              "confidence": item["confidence"],
+              "reasoning": item.get("reasoning", ""),
+              "po_number": f"PO-{item['sku']}-{{ now() | date('yyyyMMdd-HHmm') }}"
+          }
+          purchase_orders.append(po)
+
+      Kestra.outputs({
+          "purchase_orders": purchase_orders,
+          "reorder_count": len(purchase_orders),
+          "has_orders": len(purchase_orders) > 0
+      })
+
+  - id: process_orders
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.filter_and_create_orders.vars.has_orders }}"
+    then:
+      - id: submit_orders
+        type: io.kestra.plugin.core.flow.ForEach
+        values: "{{ outputs.filter_and_create_orders.vars.purchase_orders }}"
+        concurrencyLimit: 3
+        tasks:
+          - id: send_to_supplier
+            type: io.kestra.plugin.core.http.Request
+            uri: "{{ inputs.supplier_api_url }}"
+            method: POST
+            contentType: application/json
+            headers:
+              Authorization: "Bearer {{ secret('SUPPLIER_API_TOKEN') }}"
+            body: |
+              {
+                "po_number": "{{ taskrun.value | jq('.po_number') | first }}",
+                "sku": "{{ taskrun.value | jq('.sku') | first }}",
+                "quantity": {{ taskrun.value | jq('.quantity') | first }},
+                "notes": "AI forecast (confidence: {{ taskrun.value | jq('.confidence') | first }}): {{ taskrun.value | jq('.reasoning') | first }}"
+              }
+
+      - id: log_to_postgres
+        type: io.kestra.plugin.jdbc.postgresql.Queries
+        fetchType: NONE
+        sql: |
+          INSERT INTO purchase_orders (po_number, sku, quantity, forecast_confidence, reasoning, created_at)
+          SELECT
+            po->>'po_number',
+            po->>'sku',
+            (po->>'quantity')::numeric,
+            (po->>'confidence')::numeric,
+            po->>'reasoning',
+            NOW()
+          FROM json_array_elements('{{ outputs.filter_and_create_orders.vars.purchase_orders | json }}'::json) AS po
+          ON CONFLICT (po_number) DO NOTHING;
+
+      - id: notify_team
+        type: io.kestra.plugin.email.MailSend
+        from: "{{ secret('ALERT_EMAIL_FROM') }}"
+        to: "{{ secret('ALERT_EMAIL_TO') }}"
+        subject: "[Supply Chain] {{ outputs.filter_and_create_orders.vars.reorder_count }} Purchase Orders Generated"
+        htmlTextContent: |
+          <h2>Automated Purchase Orders — AI Inventory Forecast</h2>
+          <p><strong>{{ outputs.filter_and_create_orders.vars.reorder_count }}</strong> items flagged for reorder.</p>
+          <pre>{{ outputs.filter_and_create_orders.vars.purchase_orders | json }}</pre>
+          <p><em>Generated automatically by Kestra AI Inventory Forecasting workflow.</em></p>
+        host: "{{ secret('SMTP_HOST') }}"
+        username: "{{ secret('SMTP_USERNAME') }}"
+        password: "{{ secret('SMTP_PASSWORD') }}"
+        port: 465
+
+pluginDefaults:
+  - type: io.kestra.plugin.jdbc.postgresql.Queries
+    values:
+      url: "{{ secret('POSTGRES_URL') }}"
+      username: "{{ secret('POSTGRES_USER') }}"
+      password: "{{ secret('POSTGRES_PASSWORD') }}"
+
+triggers:
+  - id: every_6_hours
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 */6 * * *"
+    description: Run every 6 hours to monitor inventory and sales trends
+
+extend:
+  title: AI-Powered Inventory Demand Forecasting — Auto-Generate Purchase Orders with OpenAI
+  shortDescription: "This blueprint automates supply chain inventory management by fetching live warehouse and sales data every 6 hours, using OpenAI GPT-4o to forecast 7-day demand, generating purchase orders for items at risk of stockout, and logging everything to PostgreSQL with email notifications."
+  description: |
+    This blueprint **automates supply chain inventory management** by fetching live warehouse
+    and sales data every 6 hours, using **OpenAI GPT-4o to forecast 7-day demand**, generating
+    purchase orders for items at risk of stockout, and logging everything to PostgreSQL with
+    email notifications.
+
+    It demonstrates how to:
+
+    1. Fetch **inventory levels and sales velocity** in parallel from warehouse APIs every
+       6 hours, ensuring the forecasting model always works with the latest data.
+    2. Send combined inventory and sales data to **GPT-4o** to generate structured demand
+       forecasts using JSON Schema — predicting demand, confidence scores, and reorder
+       quantities for each SKU.
+    3. Filter the AI forecast to identify items requiring reorder and **generate purchase
+       orders** with calculated 2-week safety stock quantities.
+    4. Submit purchase orders to the **supplier API** in parallel with configurable
+       concurrency, handling each order independently for resilience.
+    5. **Upsert all orders to PostgreSQL** and send an **email digest** summarizing the
+       items reordered, quantities, and AI confidence scores.
+
+    This pattern is ideal for:
+      - **Retail and e-commerce teams** that need automated, data-driven replenishment
+        to eliminate manual stockout monitoring
+      - **Manufacturing operations** managing raw material inventory against production schedules
+      - **Supply chain teams** replacing rule-based reorder points with AI-driven demand prediction
+      - Organizations building toward **autonomous procurement** with a human-approval gate
+
+    The flow can be extended to add an approval step before submitting orders (using Kestra's
+    Human-in-the-loop pause task), integrate with ERP systems (SAP, Oracle, NetSuite) via
+    their REST APIs, add Slack alerts for high-confidence reorder recommendations, or chain
+    into a supplier comparison agent for optimal pricing.
+  tags:
+    - AI
+    - Data
+    - Business
+  ee: false
+  demo: false
+  meta_description: |
+    Automate supply chain inventory management with Kestra and OpenAI GPT-4o. Fetches warehouse
+    and sales data every 6 hours, forecasts 7-day demand, generates purchase orders for items at
+    risk of stockout, and logs to PostgreSQL with email notifications.

--- a/flows/ai-model-router.yaml
+++ b/flows/ai-model-router.yaml
@@ -1,0 +1,129 @@
+id: ai-model-router
+namespace: company.team
+
+inputs:
+  - id: question
+    type: STRING
+    displayName: User question
+    description: The question or task to route to the optimal AI model
+    defaults: "Write a Python function that implements binary search"
+
+tasks:
+  - id: classify_request
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o-mini
+    maxTokens: 10
+    jsonResponseSchema: |
+      {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["coding", "reasoning", "search", "general"]
+          }
+        },
+        "required": ["category"]
+      }
+    messages:
+      - role: system
+        content: |
+          Classify the user's request into exactly one category:
+          - "coding": writing, debugging, or explaining code
+          - "reasoning": math, logic, analysis, or multi-step problem solving
+          - "search": questions requiring recent or factual real-world information
+          - "general": everything else (summaries, creative writing, Q&A, translation)
+          Respond with JSON only.
+      - role: user
+        content: "{{ inputs.question }}"
+
+  - id: route_to_model
+    type: io.kestra.plugin.core.flow.Switch
+    value: "{{ outputs.classify_request.choices[0].message.content | json | jq('.category') | first }}"
+    cases:
+      coding:
+        - id: coding_model
+          type: io.kestra.plugin.anthropic.ChatCompletion
+          apiKey: "{{ secret('ANTHROPIC_API_KEY') }}"
+          model: claude-opus-4-5
+          maxTokens: 2048
+          messages:
+            - type: USER
+              content: "{{ inputs.question }}"
+
+      reasoning:
+        - id: reasoning_model
+          type: io.kestra.plugin.gemini.ChatCompletion
+          apiKey: "{{ secret('GEMINI_API_KEY') }}"
+          model: gemini-2.5-flash
+          messages:
+            - role: user
+              content: "{{ inputs.question }}"
+
+      search:
+        - id: search_model
+          type: io.kestra.plugin.perplexity.ChatCompletion
+          apiKey: "{{ secret('PERPLEXITY_API_KEY') }}"
+          model: sonar
+          messages:
+            - role: user
+              content: "{{ inputs.question }}"
+
+    defaults:
+      - id: general_model
+        type: io.kestra.plugin.openai.ChatCompletion
+        apiKey: "{{ secret('OPENAI_API_KEY') }}"
+        model: gpt-4o-mini
+        maxTokens: 1024
+        messages:
+          - role: user
+            content: "{{ inputs.question }}"
+
+pluginDefaults:
+  - type: io.kestra.plugin.anthropic.ChatCompletion
+    values:
+      apiKey: "{{ secret('ANTHROPIC_API_KEY') }}"
+
+extend:
+  title: Route AI Requests to the Optimal Model Based on Query Classification
+  shortDescription: "This blueprint implements an AI model router that first classifies the user's request into one of four categories, then automatically dispatches it to the most suitable LLM — balancing quality, cost, and specialized capability."
+  description: |
+    This blueprint implements an **AI model router** that first classifies the user's
+    request into one of four categories, then **automatically dispatches it to the most
+    suitable LLM** — balancing quality, cost, and specialized capability across providers.
+
+    It demonstrates how to:
+
+    1. Use **GPT-4o-mini** as a lightweight, cost-efficient classifier to categorize
+       each incoming request as `coding`, `reasoning`, `search`, or `general` using
+       structured JSON output.
+    2. Route **coding requests** to **Claude Opus** (Anthropic), which excels at code
+       generation, debugging, and technical explanation.
+    3. Route **reasoning requests** to **Gemini Flash Thinking** (Google), optimized
+       for multi-step logic, mathematical analysis, and chain-of-thought problems.
+    4. Route **search requests** to **Perplexity Sonar**, which performs real-time
+       web retrieval to answer questions requiring current factual information.
+    5. Route all other **general requests** to **GPT-4o-mini** for cost-efficient
+       response generation.
+
+    This pattern is ideal for:
+      - **AI platforms and chatbots** that serve diverse query types and need to optimize
+        model selection per request
+      - **Cost-conscious teams** that want to avoid using expensive frontier models for
+        simple tasks
+      - **Developers building multi-provider AI pipelines** who need observable, auditable
+        routing logic
+      - Scenarios where **specialized models outperform general models** for specific domains
+
+    The flow can be extended to add additional model providers, weight routing decisions
+    by cost or latency targets, implement A/B testing across models, or log classification
+    outcomes and response quality to a monitoring database for continuous improvement.
+  tags:
+    - AI
+    - Engineering
+  ee: false
+  demo: false
+  meta_description: |
+    Intelligently route AI requests to the optimal model using query classification. Classifies
+    each question as coding, reasoning, search, or general, then dispatches to Claude Opus,
+    Gemini Thinking, Perplexity Sonar, or GPT-4o-mini accordingly.

--- a/flows/ai-model-router.yaml
+++ b/flows/ai-model-router.yaml
@@ -86,6 +86,7 @@ pluginDefaults:
 
 extend:
   title: Route AI Requests to the Optimal Model Based on Query Classification
+  metaTitle: AI Model Router with Query Classification
   shortDescription: "This blueprint implements an AI model router that first classifies the user's request into one of four categories, then automatically dispatches it to the most suitable LLM — balancing quality, cost, and specialized capability."
   description: |
     This blueprint implements an **AI model router** that first classifies the user's
@@ -123,7 +124,4 @@ extend:
     - Engineering
   ee: false
   demo: false
-  meta_description: |
-    Intelligently route AI requests to the optimal model using query classification. Classifies
-    each question as coding, reasoning, search, or general, then dispatches to Claude Opus,
-    Gemini Thinking, Perplexity Sonar, or GPT-4o-mini accordingly.
+  metaDescription: Route AI requests to the optimal model with Kestra. Classifies queries as coding, reasoning, search, or general, then dispatches to the best-fit LLM.

--- a/flows/ai-model-router.yaml
+++ b/flows/ai-model-router.yaml
@@ -121,7 +121,7 @@ extend:
     outcomes and response quality to a monitoring database for continuous improvement.
   tags:
     - AI
-    - Engineering
+    - Core
   ee: false
   demo: false
   metaDescription: Route AI requests to the optimal model with Kestra. Classifies queries as coding, reasoning, search, or general, then dispatches to the best-fit LLM.

--- a/flows/ai-rag-ingest-and-query.yaml
+++ b/flows/ai-rag-ingest-and-query.yaml
@@ -61,6 +61,7 @@ tasks:
 
 extend:
   title: Build a RAG Pipeline — Ingest Documents and Answer Questions Using OpenAI
+  metaTitle: Build a RAG Pipeline with OpenAI
   shortDescription: "This blueprint implements a Retrieval-Augmented Generation (RAG) pipeline that ingests documents from public URLs into a vector store, then answers natural language questions grounded in the indexed content."
   description: |
     This blueprint implements a **Retrieval-Augmented Generation (RAG) pipeline** that
@@ -97,7 +98,4 @@ extend:
     - AI
   ee: false
   demo: false
-  meta_description: |
-    Build a RAG pipeline with Kestra and OpenAI. Ingest documents from URLs into a KV-backed
-    vector store, split them into semantically meaningful chunks, and answer natural language
-    questions grounded in the retrieved content using an AI agent with GPT-4o.
+  metaDescription: Build a RAG pipeline with Kestra and OpenAI. Ingest documents into a vector store, split into chunks, and answer questions grounded in retrieved content.

--- a/flows/ai-rag-ingest-and-query.yaml
+++ b/flows/ai-rag-ingest-and-query.yaml
@@ -1,0 +1,103 @@
+id: ai-rag-ingest-and-query
+namespace: company.team
+
+inputs:
+  - id: document_urls
+    type: ARRAY
+    itemType: STRING
+    displayName: Document URLs to ingest
+    description: List of public document URLs (PDF, TXT, HTML) to index into the vector store
+    defaults:
+      - "https://raw.githubusercontent.com/kestra-io/kestra/develop/README.md"
+  - id: question
+    type: STRING
+    displayName: Question
+    description: Natural language question to answer from the indexed documents
+    defaults: "What is Kestra and what are its main capabilities?"
+
+tasks:
+  - id: ingest_documents
+    type: io.kestra.plugin.ai.rag.IngestDocument
+    fromExternalURLs: "{{ inputs.document_urls }}"
+    drop: true
+    documentSplitter:
+      splitter: RECURSIVE
+      maxSegmentSizeInChars: 1000
+      maxOverlapSizeInChars: 200
+    provider:
+      type: io.kestra.plugin.ai.provider.OpenAI
+      apiKey: "{{ secret('OPENAI_API_KEY') }}"
+      modelName: text-embedding-3-small
+    embeddings:
+      type: io.kestra.plugin.ai.embeddings.KestraKVStore
+
+  - id: answer_question
+    type: io.kestra.plugin.ai.agent.AIAgent
+    systemMessage: |
+      You are a knowledgeable assistant. Answer the user's question using only
+      the information retrieved from the indexed documents. If the answer is
+      not found in the documents, say:
+      "I could not find relevant information in the provided documents."
+      Be concise and factual.
+    prompt: "{{ inputs.question }}"
+    contentRetrievers:
+      - type: io.kestra.plugin.ai.retriever.EmbeddingStoreRetriever
+        embeddings:
+          type: io.kestra.plugin.ai.embeddings.KestraKVStore
+        embeddingProvider:
+          type: io.kestra.plugin.ai.provider.OpenAI
+          apiKey: "{{ secret('OPENAI_API_KEY') }}"
+          modelName: text-embedding-3-small
+        maxResults: 5
+        minScore: 0.6
+    provider:
+      type: io.kestra.plugin.ai.provider.OpenAI
+      apiKey: "{{ secret('OPENAI_API_KEY') }}"
+      modelName: gpt-4o
+
+  - id: log_answer
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ outputs.answer_question.textOutput }}"
+
+extend:
+  title: Build a RAG Pipeline — Ingest Documents and Answer Questions Using OpenAI
+  shortDescription: "This blueprint implements a Retrieval-Augmented Generation (RAG) pipeline that ingests documents from public URLs into a vector store, then answers natural language questions grounded in the indexed content."
+  description: |
+    This blueprint implements a **Retrieval-Augmented Generation (RAG) pipeline** that
+    ingests documents from public URLs into a vector store, then answers **natural language
+    questions grounded in the indexed content** — preventing hallucinations by constraining
+    the AI to retrieved context.
+
+    It demonstrates how to:
+
+    1. Ingest one or more documents from public URLs into a **KV-backed vector store**
+       using Kestra's native RAG plugin, replacing any previous index on each run to keep
+       the knowledge base current.
+    2. Split documents using **recursive text splitting** with configurable segment size
+       and overlap to preserve semantic context across chunk boundaries.
+    3. Generate **vector embeddings** using OpenAI's `text-embedding-3-small` model and
+       store them in the **Kestra KV Store** for lightweight, zero-infrastructure retrieval.
+    4. Answer a user's question with an **AI agent** that first retrieves the top-5 most
+       relevant chunks via semantic similarity search, then passes them as grounding
+       context to **GPT-4o** before generating a response.
+    5. Constrain the AI to retrieved content to prevent hallucinations and ensure
+       **source-faithful answers**.
+
+    This pattern is ideal for:
+      - **Internal knowledge bases** where teams need to query documentation, runbooks, or policies
+      - **Document Q&A tools** built on top of PDFs, Markdown files, or public web content
+      - **Proof-of-concept RAG systems** that need to be production-ready quickly
+      - Teams evaluating RAG architectures before committing to an external vector database
+
+    The flow can be extended to swap the KV store for a production-grade vector database
+    (Qdrant, Elasticsearch, or Pinecone via the `embeddings` configuration), add a trigger
+    that automatically re-ingests documents when source files change, or chain into a Slack
+    notification with the answer.
+  tags:
+    - AI
+  ee: false
+  demo: false
+  meta_description: |
+    Build a RAG pipeline with Kestra and OpenAI. Ingest documents from URLs into a KV-backed
+    vector store, split them into semantically meaningful chunks, and answer natural language
+    questions grounded in the retrieved content using an AI agent with GPT-4o.

--- a/flows/ai-rss-news-digest.yaml
+++ b/flows/ai-rss-news-digest.yaml
@@ -138,6 +138,7 @@ triggers:
 
 extend:
   title: Generate and Deliver an AI-Powered Daily News Digest from RSS Feeds via Slack and Email
+  metaTitle: AI-Powered Daily News Digest from RSS Feeds
   shortDescription: "This blueprint aggregates articles from multiple configurable RSS feeds, filters for the last 48 hours, uses OpenAI GPT-4o-mini to produce a focused daily digest in any language, and delivers it to Slack and email every morning."
   description: |
     This blueprint **aggregates articles from multiple configurable RSS feeds**, filters
@@ -173,7 +174,4 @@ extend:
     - Business
   ee: false
   demo: false
-  meta_description: |
-    Automate daily news intelligence with Kestra and OpenAI. Fetches multiple RSS feeds in
-    parallel, filters for recent articles, generates an AI-curated digest focused on a
-    configurable topic, and delivers it via Slack and email every morning.
+  metaDescription: Automate daily news intelligence with Kestra and OpenAI. Fetches RSS feeds in parallel, filters recent articles, and delivers an AI-curated digest via Slack and email.

--- a/flows/ai-rss-news-digest.yaml
+++ b/flows/ai-rss-news-digest.yaml
@@ -1,0 +1,179 @@
+id: ai-rss-news-digest
+namespace: company.team
+
+inputs:
+  - id: rss_feeds
+    type: ARRAY
+    itemType: STRING
+    displayName: RSS feed URLs
+    description: List of RSS feed URLs to fetch articles from
+    defaults:
+      - "https://feeds.feedburner.com/TechCrunch"
+      - "https://hnrss.org/frontpage"
+      - "https://www.wired.com/feed/rss"
+      - "https://news.google.com/rss/topics/CAAqJggKIiBDQkFTRWdvSUwyMHZNRGRqTVhZU0FtVnVHZ0pWVXlnQVAB"
+  - id: max_articles
+    type: INT
+    displayName: Max articles per feed
+    description: Maximum number of articles to process per feed
+    defaults: 5
+  - id: digest_language
+    type: STRING
+    displayName: Digest language
+    description: Language for the AI-generated digest (e.g., English, French, Spanish)
+    defaults: "English"
+  - id: digest_topic_focus
+    type: STRING
+    displayName: Topic focus
+    description: Optional topic focus for the AI summary (e.g., "AI and machine learning", "security vulnerabilities")
+    defaults: "technology and software engineering"
+
+tasks:
+  - id: fetch_feeds
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ inputs.rss_feeds }}"
+    concurrencyLimit: 4
+    tasks:
+      - id: fetch_rss
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ taskrun.value }}"
+        method: GET
+        headers:
+          Accept: "application/rss+xml, application/xml, text/xml"
+
+  - id: parse_and_summarize
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      feeds_raw.json: "{{ outputs.fetch_feeds | json }}"
+    dependencies:
+      - feedparser
+    script: |
+      import json
+      import feedparser
+      from datetime import datetime, timezone, timedelta
+      from kestra import Kestra
+
+      with open("feeds_raw.json") as f:
+          raw = json.load(f)
+
+      max_per_feed = {{ inputs.max_articles }}
+      cutoff = datetime.now(timezone.utc) - timedelta(hours=48)
+
+      articles = []
+      for feed_url, feed_data in raw.items():
+          body = feed_data.get("body", "")
+          parsed = feedparser.parse(body)
+          for entry in parsed.entries[:max_per_feed]:
+              pub_date = entry.get("published_parsed")
+              if pub_date:
+                  pub_dt = datetime(*pub_date[:6], tzinfo=timezone.utc)
+                  if pub_dt < cutoff:
+                      continue
+              articles.append({
+                  "title": entry.get("title", ""),
+                  "link": entry.get("link", ""),
+                  "summary": entry.get("summary", "")[:500],
+                  "published": str(entry.get("published", ""))
+              })
+
+      # Sort by newest first, limit to 20
+      articles = articles[:20]
+      Kestra.outputs({"articles": articles, "count": len(articles)})
+
+  - id: generate_digest
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o-mini
+    maxTokens: 1000
+    messages:
+      - role: system
+        content: |
+          You are a professional tech journalist. Given a list of recent news articles,
+          write a concise daily digest in {{ inputs.digest_language }}.
+
+          Focus on: {{ inputs.digest_topic_focus }}
+
+          Format the digest as:
+          ## 📰 Daily Digest — [Today's Date]
+
+          **Key Themes:** [2-3 bullet summary of major themes]
+
+          ### Top Stories
+          1. **[Title]** — [1-2 sentence summary with key insight] ([link])
+          2. ...
+
+          ### What to Watch
+          [1-2 sentences on emerging trends or stories to follow]
+
+          Be concise, factual, and professional. No fluff.
+      - role: user
+        content: "Here are today's articles:\n{{ outputs.parse_and_summarize.vars.articles | json }}"
+
+  - id: send_to_slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    messageText: "{{ outputs.generate_digest.choices[0].message.content }}"
+
+  - id: send_email_digest
+    type: io.kestra.plugin.email.MailSend
+    from: "{{ secret('DIGEST_EMAIL_FROM') }}"
+    to: "{{ secret('DIGEST_EMAIL_TO') }}"
+    subject: "Daily Tech Digest — {{ now() | date('yyyy-MM-dd') }}"
+    htmlTextContent: |
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <pre style="white-space: pre-wrap; font-family: Arial, sans-serif;">{{ outputs.generate_digest.choices[0].message.content }}</pre>
+        <hr>
+        <p style="color: #888; font-size: 12px;">{{ outputs.parse_and_summarize.vars.count }} articles processed from {{ inputs.rss_feeds | length }} feeds.</p>
+      </div>
+    host: "{{ secret('SMTP_HOST') }}"
+    username: "{{ secret('SMTP_USERNAME') }}"
+    password: "{{ secret('SMTP_PASSWORD') }}"
+    port: 465
+
+triggers:
+  - id: morning_digest
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 7 * * *"
+    description: Generate and deliver the daily digest every morning at 07:00 UTC
+
+extend:
+  title: Generate and Deliver an AI-Powered Daily News Digest from RSS Feeds via Slack and Email
+  shortDescription: "This blueprint aggregates articles from multiple configurable RSS feeds, filters for the last 48 hours, uses OpenAI GPT-4o-mini to produce a focused daily digest in any language, and delivers it to Slack and email every morning."
+  description: |
+    This blueprint **aggregates articles from multiple configurable RSS feeds**, filters
+    for the last 48 hours, uses **OpenAI GPT-4o-mini** to produce a focused daily digest in
+    any language, and delivers it to **Slack and email** every morning — replacing manual
+    news browsing with an automated, AI-curated briefing.
+
+    It demonstrates how to:
+
+    1. Fetch multiple RSS feeds in parallel using the HTTP plugin and parse the XML content
+       with Python's **feedparser** library to normalize articles across feed formats.
+    2. Filter articles to only include those published within the **last 48 hours**,
+       preventing stale content from diluting the digest.
+    3. Send the normalized article list to **GPT-4o-mini** with a configurable topic focus
+       and language, generating a structured digest with key themes, top story summaries,
+       and trend observations.
+    4. Deliver the digest to a **Slack webhook** for instant team-wide distribution and
+       send a formatted **HTML email** for inbox consumption.
+
+    This pattern is ideal for:
+      - **Engineering teams** that want a daily briefing on what's trending in their
+        technical domain without manually reading five blogs
+      - **Tech newsletter authors** who want an automated first draft to edit and publish
+      - **Product managers and founders** who track competitor news and industry signals
+      - **Anyone** who wants personalized AI news curation delivered without lifting a finger
+
+    The flow can be extended to add keyword filtering so only articles matching specific
+    topics are included, store the digest in Notion or a database for archiving,
+    support multiple digest topics with separate Slack channels, or add a Telegram
+    delivery channel alongside Slack and email.
+  tags:
+    - AI
+    - Business
+  ee: false
+  demo: false
+  meta_description: |
+    Automate daily news intelligence with Kestra and OpenAI. Fetches multiple RSS feeds in
+    parallel, filters for recent articles, generates an AI-curated digest focused on a
+    configurable topic, and delivers it via Slack and email every morning.

--- a/flows/ai-semantic-cache-redis.yaml
+++ b/flows/ai-semantic-cache-redis.yaml
@@ -1,0 +1,113 @@
+id: ai-semantic-cache-redis
+namespace: company.team
+
+inputs:
+  - id: question
+    type: STRING
+    displayName: User question
+    description: Question to answer — checked against the semantic cache before calling the LLM
+    defaults: "What is your refund policy?"
+  - id: cache_key_prefix
+    type: STRING
+    displayName: Cache key prefix
+    description: Namespace prefix for Redis cache keys (useful for multi-tenant setups)
+    defaults: "ai_cache"
+
+tasks:
+  - id: generate_cache_key
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import hashlib
+      import re
+
+      question = "{{ inputs.question }}"
+      prefix = "{{ inputs.cache_key_prefix }}"
+
+      # Normalize: lowercase, strip punctuation, collapse whitespace
+      normalized = re.sub(r'[^\w\s]', '', question.lower().strip())
+      normalized = re.sub(r'\s+', ' ', normalized)
+
+      # Create deterministic cache key from normalized question
+      cache_key = f"{prefix}:{hashlib.md5(normalized.encode()).hexdigest()}"
+
+      print(f"Cache key: {cache_key}")
+      print(f"Normalized: {normalized}")
+
+      from kestra import Kestra
+      Kestra.outputs({'cache_key': cache_key, 'normalized_question': normalized})
+
+  - id: check_cache
+    type: io.kestra.plugin.redis.string.Get
+    url: "{{ secret('REDIS_URL') }}"
+    key: "{{ outputs.generate_cache_key.vars.cache_key }}"
+    failedOnMissing: false
+
+  - id: route_request
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.check_cache.value != null and outputs.check_cache.value != '' }}"
+    then:
+      - id: serve_from_cache
+        type: io.kestra.plugin.core.log.Log
+        message: "CACHE HIT — {{ outputs.check_cache.value }}"
+    else:
+      - id: call_llm
+        type: io.kestra.plugin.openai.ChatCompletion
+        apiKey: "{{ secret('OPENAI_API_KEY') }}"
+        model: gpt-4o
+        maxTokens: 512
+        messages:
+          - role: system
+            content: "You are a helpful customer support assistant. Answer questions accurately and concisely."
+          - role: user
+            content: "{{ inputs.question }}"
+
+      - id: store_in_cache
+        type: io.kestra.plugin.redis.string.Set
+        url: "{{ secret('REDIS_URL') }}"
+        key: "{{ outputs.generate_cache_key.vars.cache_key }}"
+        value: "{{ outputs.call_llm.choices[0].message.content }}"
+
+      - id: log_llm_response
+        type: io.kestra.plugin.core.log.Log
+        message: "LLM RESPONSE — {{ outputs.call_llm.choices[0].message.content }}"
+
+extend:
+  title: Reduce LLM API Costs with a Redis Semantic Cache for Repeated Questions
+  shortDescription: "This blueprint implements a semantic caching layer in front of an OpenAI LLM using Redis, serving instant responses for previously answered questions and calling the API only on genuine cache misses."
+  description: |
+    This blueprint implements a **semantic caching layer in front of an OpenAI LLM using Redis**,
+    serving instant responses for previously answered questions and calling the LLM API only on
+    genuine cache misses — cutting costs and latency for FAQ-heavy workloads.
+
+    It demonstrates how to:
+
+    1. **Normalize and hash** the user's question into a deterministic Redis key using
+       text normalization (lowercase, punctuation removal, whitespace collapse) and MD5
+       hashing — so semantically equivalent questions map to the same cache entry.
+    2. **Check Redis** for a previously stored answer using the computed cache key, treating
+       a null response as a cache miss.
+    3. Conditionally **serve a cached response instantly** when a matching key exists,
+       avoiding any LLM API call.
+    4. On cache miss, **call OpenAI GPT-4o** to generate a fresh answer, then **write
+       the result back to Redis** for future lookups.
+
+    This pattern is ideal for:
+      - **Customer support chatbots** where users repeatedly ask the same questions in
+        slightly different phrasing
+      - **Documentation assistants** with a bounded knowledge domain and high query repetition
+      - **Internal FAQ systems** where LLM API cost and latency are optimization targets
+      - Any workflow where **deterministic or near-deterministic answers** can be safely cached
+
+    The flow can be extended to set Redis key TTL for cache expiration, add a similarity
+    threshold so semantically close-but-different questions are not incorrectly served cached
+    answers, log cache hit/miss rates to a monitoring dashboard, or build a true semantic
+    cache using vector similarity with the Kestra AI RAG plugin.
+  tags:
+    - AI
+    - Engineering
+  ee: false
+  demo: false
+  meta_description: |
+    Reduce LLM API costs by caching answers in Redis. Normalizes questions into deterministic
+    cache keys and serves instant responses on hits — calling OpenAI GPT-4o only when no
+    matching cached answer exists.

--- a/flows/ai-semantic-cache-redis.yaml
+++ b/flows/ai-semantic-cache-redis.yaml
@@ -73,6 +73,7 @@ tasks:
 
 extend:
   title: Reduce LLM API Costs with a Redis Semantic Cache for Repeated Questions
+  metaTitle: Redis Semantic Cache for LLM API Costs
   shortDescription: "This blueprint implements a semantic caching layer in front of an OpenAI LLM using Redis, serving instant responses for previously answered questions and calling the API only on genuine cache misses."
   description: |
     This blueprint implements a **semantic caching layer in front of an OpenAI LLM using Redis**,
@@ -107,7 +108,4 @@ extend:
     - Engineering
   ee: false
   demo: false
-  meta_description: |
-    Reduce LLM API costs by caching answers in Redis. Normalizes questions into deterministic
-    cache keys and serves instant responses on hits — calling OpenAI GPT-4o only when no
-    matching cached answer exists.
+  metaDescription: Reduce LLM API costs by caching answers in Redis with Kestra. Normalizes questions into cache keys and serves instant responses on cache hits.

--- a/flows/ai-semantic-cache-redis.yaml
+++ b/flows/ai-semantic-cache-redis.yaml
@@ -105,7 +105,7 @@ extend:
     cache using vector similarity with the Kestra AI RAG plugin.
   tags:
     - AI
-    - Engineering
+    - Core
   ee: false
   demo: false
   metaDescription: Reduce LLM API costs by caching answers in Redis with Kestra. Normalizes questions into cache keys and serves instant responses on cache hits.

--- a/flows/ai-slack-chatbot-with-memory.yaml
+++ b/flows/ai-slack-chatbot-with-memory.yaml
@@ -1,0 +1,180 @@
+id: ai-slack-chatbot-with-memory
+namespace: company.team
+
+inputs:
+  - id: user_message
+    type: STRING
+    displayName: User message
+    description: The message sent by the user (passed from Slack webhook payload)
+  - id: user_id
+    type: STRING
+    displayName: Slack user ID
+    description: Slack user ID for per-user conversation history (e.g., U12345678)
+  - id: channel_id
+    type: STRING
+    displayName: Slack channel or DM ID
+    description: Slack channel or DM channel to post the response to (e.g., C12345678 or D12345678)
+  - id: system_prompt
+    type: STRING
+    displayName: Bot system prompt
+    description: System instruction defining the chatbot's persona and capabilities
+    defaults: "You are a helpful assistant. Answer questions clearly and concisely. If asked about something outside your knowledge, say so honestly."
+  - id: max_history_turns
+    type: INT
+    displayName: Max conversation turns to retain
+    description: Number of previous message pairs (user+assistant) to include as context (max 10)
+    defaults: 5
+
+tasks:
+  - id: load_conversation_history
+    type: io.kestra.plugin.core.kv.Get
+    key: "chat_history_{{ inputs.user_id }}"
+    errorOnMissing: false
+
+  - id: build_and_respond
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      history_raw.json: "{{ outputs.load_conversation_history.value | default('[]') }}"
+    script: |
+      import json
+      from kestra import Kestra
+
+      # Load existing history
+      try:
+          with open("history_raw.json") as f:
+              content = f.read().strip()
+              history = json.loads(content) if content and content != 'null' else []
+      except Exception:
+          history = []
+
+      if not isinstance(history, list):
+          history = []
+
+      max_turns = {{ inputs.max_history_turns }}
+
+      # Trim to max_turns pairs (each turn = user + assistant message)
+      if len(history) > max_turns * 2:
+          history = history[-(max_turns * 2):]
+
+      # Build messages for OpenAI: system + history + new user message
+      messages = [{"role": "system", "content": """{{ inputs.system_prompt | replace('"', '\\"') }}"""}]
+      messages.extend(history)
+      messages.append({"role": "user", "content": """{{ inputs.user_message | replace('"', '\\"') }}"""})
+
+      Kestra.outputs({"messages": messages, "history_length": len(history)})
+
+  - id: generate_response
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o-mini
+    maxTokens: 800
+    messages: "{{ outputs.build_and_respond.vars.messages }}"
+
+  - id: update_conversation_history
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      history_raw.json: "{{ outputs.load_conversation_history.value | default('[]') }}"
+    script: |
+      import json
+      from kestra import Kestra
+
+      try:
+          with open("history_raw.json") as f:
+              content = f.read().strip()
+              history = json.loads(content) if content and content != 'null' else []
+      except Exception:
+          history = []
+
+      if not isinstance(history, list):
+          history = []
+
+      max_turns = {{ inputs.max_history_turns }}
+      ai_reply = """{{ outputs.generate_response.choices[0].message.content | replace('"', '\\"') | replace('\n', '\\n') }}"""
+
+      # Append new exchange
+      history.append({"role": "user", "content": """{{ inputs.user_message | replace('"', '\\"') }}"""})
+      history.append({"role": "assistant", "content": ai_reply})
+
+      # Keep only the last max_turns * 2 messages
+      if len(history) > max_turns * 2:
+          history = history[-(max_turns * 2):]
+
+      Kestra.outputs({"updated_history": json.dumps(history)})
+
+  - id: save_conversation_history
+    type: io.kestra.plugin.core.kv.Set
+    key: "chat_history_{{ inputs.user_id }}"
+    value: "{{ outputs.update_conversation_history.vars.updated_history }}"
+    kvType: STRING
+
+  - id: post_reply_to_slack
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://slack.com/api/chat.postMessage"
+    method: POST
+    contentType: "application/json"
+    headers:
+      Authorization: "Bearer {{ secret('SLACK_BOT_TOKEN') }}"
+    body: |
+      {
+        "channel": "{{ inputs.channel_id }}",
+        "text": "{{ outputs.generate_response.choices[0].message.content | replace('"', '\\"') | replace('\n', '\\n') }}",
+        "mrkdwn": true
+      }
+
+triggers:
+  - id: slack_message_webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "{{ secret('SLACK_WEBHOOK_KEY') }}"
+    description: |
+      Receives POST requests from the Slack Events API (event_type: message).
+      Configure your Slack app's Event Subscriptions URL to:
+      https://<your-kestra-host>/api/v1/executions/webhook/company.team/ai-slack-chatbot-with-memory/<SLACK_WEBHOOK_KEY>
+      Map trigger.body fields to flow inputs in the Slack app configuration or use a pre-processing flow.
+
+extend:
+  title: AI Slack Chatbot with Per-User Conversation Memory Using OpenAI and KV Store
+  shortDescription: "This blueprint powers a Slack chatbot with persistent per-user conversation history — each message triggers a Kestra flow that loads the user's chat history from KV store, sends the full conversation to OpenAI GPT-4o-mini, posts the response back to Slack, and saves the updated history for the next turn."
+  description: |
+    This blueprint **powers a Slack chatbot with persistent per-user conversation history** —
+    each message triggers a Kestra execution that loads the user's chat history from the
+    **KV store**, sends the full conversation thread to **OpenAI GPT-4o-mini**, posts the
+    response back to Slack via the Bot API, and saves the updated history for the next turn.
+
+    It demonstrates how to:
+
+    1. Receive **Slack messages via a Kestra Webhook trigger**, with the message text, user ID,
+       and channel ID passed as flow inputs — enabling integration with Slack's Event Subscriptions
+       API or Slash Command endpoints.
+    2. Load the **per-user conversation history** from Kestra's KV store using a user-scoped key
+       (`chat_history_<user_id>`), enabling isolated memory per Slack user across all conversations.
+    3. Build the **full OpenAI messages array** in Python by combining the system prompt, trimmed
+       history (configurable max turns), and the new user message — giving the model full
+       conversational context without unbounded token growth.
+    4. Send to **GPT-4o-mini** for fast, cost-efficient responses and **persist the updated
+       conversation history** back to KV store with automatic sliding-window trimming.
+    5. **Post the AI response to Slack** via `chat.postMessage` with Markdown rendering enabled,
+       delivering a seamless chat experience with sub-second response time for short queries.
+
+    This pattern is ideal for:
+      - **Engineering and operations teams** deploying an internal assistant in Slack that
+        remembers context across a multi-turn troubleshooting session
+      - **Customer support teams** building a first-line AI triage bot that maintains conversation
+        context and escalates to humans when needed
+      - **Product and documentation teams** creating a searchable knowledge assistant in Slack
+        with a custom persona and restricted knowledge domain
+      - **Developers** learning how to implement stateful AI conversations without a dedicated
+        conversation management service
+
+    The flow can be extended to add a `/reset` command that clears the KV store history, integrate
+    with RAG (`io.kestra.plugin.ai.rag.IngestDocument`) for knowledge-base-grounded responses,
+    add conversation logging to Postgres for analytics, support threaded Slack replies to keep
+    each conversation in its own thread, or add human escalation when the AI flags low confidence.
+  tags:
+    - AI
+    - Business
+  ee: false
+  demo: false
+  meta_description: |
+    Build a stateful Slack AI chatbot with Kestra and OpenAI GPT-4o-mini. Loads per-user
+    conversation history from KV store, maintains a sliding-window context window, generates
+    responses, posts back to Slack, and persists updated history — no external database required.

--- a/flows/ai-slack-chatbot-with-memory.yaml
+++ b/flows/ai-slack-chatbot-with-memory.yaml
@@ -133,6 +133,7 @@ triggers:
 
 extend:
   title: AI Slack Chatbot with Per-User Conversation Memory Using OpenAI and KV Store
+  metaTitle: AI Slack Chatbot with Conversation Memory
   shortDescription: "This blueprint powers a Slack chatbot with persistent per-user conversation history — each message triggers a Kestra flow that loads the user's chat history from KV store, sends the full conversation to OpenAI GPT-4o-mini, posts the response back to Slack, and saves the updated history for the next turn."
   description: |
     This blueprint **powers a Slack chatbot with persistent per-user conversation history** —
@@ -174,7 +175,4 @@ extend:
     - Business
   ee: false
   demo: false
-  meta_description: |
-    Build a stateful Slack AI chatbot with Kestra and OpenAI GPT-4o-mini. Loads per-user
-    conversation history from KV store, maintains a sliding-window context window, generates
-    responses, posts back to Slack, and persists updated history — no external database required.
+  metaDescription: Build a stateful Slack AI chatbot with Kestra and OpenAI. Loads per-user conversation history from KV store and maintains context across messages.

--- a/flows/ai-stock-analysis-alerts.yaml
+++ b/flows/ai-stock-analysis-alerts.yaml
@@ -1,0 +1,263 @@
+id: ai-stock-analysis-alerts
+namespace: company.team
+
+inputs:
+  - id: watchlist
+    type: ARRAY
+    itemType: STRING
+    displayName: Stock watchlist (tickers)
+    description: List of stock ticker symbols to analyze
+    defaults:
+      - "AAPL"
+      - "MSFT"
+      - "GOOGL"
+      - "NVDA"
+      - "TSLA"
+  - id: analysis_horizon
+    type: STRING
+    displayName: Analysis horizon
+    description: Time horizon for AI recommendations (e.g., "short-term (1-2 weeks)", "medium-term (1-3 months)")
+    defaults: "short-term (1-2 weeks)"
+  - id: risk_profile
+    type: SELECT
+    displayName: Risk profile
+    description: Investor risk tolerance — shapes the AI recommendation style
+    values:
+      - conservative
+      - moderate
+      - aggressive
+    defaults: "moderate"
+
+tasks:
+  - id: fetch_market_data
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ inputs.watchlist }}"
+    concurrencyLimit: 5
+    tasks:
+      - id: fetch_quote
+        type: io.kestra.plugin.core.http.Request
+        uri: "https://query1.finance.yahoo.com/v8/finance/chart/{{ taskrun.value }}?interval=1d&range=30d"
+        method: GET
+        headers:
+          User-Agent: "Mozilla/5.0"
+
+  - id: prepare_analysis_data
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      quotes_raw.json: "{{ outputs.fetch_market_data | json }}"
+    script: |
+      import json
+      from kestra import Kestra
+
+      with open("quotes_raw.json") as f:
+          raw = json.load(f)
+
+      stocks = []
+      for ticker, task_output in raw.items():
+          body = task_output.get("body", "{}")
+          if isinstance(body, str):
+              try:
+                  data = json.loads(body)
+              except Exception:
+                  continue
+          else:
+              data = body
+
+          try:
+              result = data["chart"]["result"][0]
+              meta = result["meta"]
+              closes = result["indicators"]["quote"][0].get("closes") or result["indicators"]["quote"][0].get("close", [])
+              closes = [c for c in closes if c is not None]
+
+              if len(closes) < 2:
+                  continue
+
+              current_price = closes[-1]
+              prev_price = closes[-2]
+              price_30d_ago = closes[0]
+
+              day_change_pct = ((current_price - prev_price) / prev_price) * 100
+              month_change_pct = ((current_price - price_30d_ago) / price_30d_ago) * 100
+
+              # Simple RSI approximation (14-day)
+              gains = [max(0, closes[i] - closes[i-1]) for i in range(1, len(closes))]
+              losses = [max(0, closes[i-1] - closes[i]) for i in range(1, len(closes))]
+              avg_gain = sum(gains[-14:]) / 14 if len(gains) >= 14 else sum(gains) / len(gains) if gains else 0
+              avg_loss = sum(losses[-14:]) / 14 if len(losses) >= 14 else sum(losses) / len(losses) if losses else 0
+              rsi = 100 - (100 / (1 + avg_gain / avg_loss)) if avg_loss > 0 else 100
+
+              stocks.append({
+                  "ticker": meta.get("symbol", ticker),
+                  "current_price": round(current_price, 2),
+                  "day_change_pct": round(day_change_pct, 2),
+                  "month_change_pct": round(month_change_pct, 2),
+                  "rsi_14d": round(rsi, 1),
+                  "52w_high": meta.get("fiftyTwoWeekHigh"),
+                  "52w_low": meta.get("fiftyTwoWeekLow"),
+                  "currency": meta.get("currency", "USD"),
+                  "price_history_30d": [round(c, 2) for c in closes[-10:]]
+              })
+          except (KeyError, IndexError, ZeroDivisionError, TypeError):
+              continue
+
+      stocks.sort(key=lambda x: abs(x["day_change_pct"]), reverse=True)
+      Kestra.outputs({"stocks": stocks, "count": len(stocks)})
+
+  - id: generate_ai_analysis
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 1500
+    jsonResponseSchema: |
+      {
+        "type": "object",
+        "properties": {
+          "market_summary": {"type": "string"},
+          "recommendations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ticker": {"type": "string"},
+                "action": {"type": "string", "enum": ["BUY", "HOLD", "SELL", "WATCH"]},
+                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                "rationale": {"type": "string"},
+                "key_levels": {"type": "string"}
+              },
+              "required": ["ticker", "action", "confidence", "rationale"]
+            }
+          },
+          "risk_flags": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["market_summary", "recommendations"]
+      }
+    messages:
+      - role: system
+        content: |
+          You are a quantitative stock analyst providing technical analysis recommendations.
+          Risk profile: {{ inputs.risk_profile }}
+          Time horizon: {{ inputs.analysis_horizon }}
+
+          For each stock, analyze: momentum (day/month % change), RSI (overbought >70, oversold <30),
+          proximity to 52-week highs/lows, and relative performance.
+
+          Provide actionable recommendations (BUY/HOLD/SELL/WATCH) calibrated to the risk profile:
+          - conservative: prioritize capital preservation, flag high volatility
+          - moderate: balanced risk/reward, standard momentum signals
+          - aggressive: favor momentum plays, higher confidence thresholds
+
+          This is for educational/informational purposes only — not financial advice.
+          Return structured JSON only.
+      - role: user
+        content: |
+          Analyze these stocks for {{ inputs.analysis_horizon }} {{ inputs.risk_profile }} strategy:
+          {{ outputs.prepare_analysis_data.vars.stocks | json }}
+
+  - id: log_to_postgres
+    type: io.kestra.plugin.jdbc.postgresql.Queries
+    fetchType: NONE
+    sql: |
+      CREATE TABLE IF NOT EXISTS stock_analysis_log (
+          id SERIAL PRIMARY KEY,
+          ticker TEXT,
+          action TEXT,
+          confidence NUMERIC,
+          current_price NUMERIC,
+          day_change_pct NUMERIC,
+          rsi_14d NUMERIC,
+          rationale TEXT,
+          risk_profile TEXT,
+          analyzed_at TIMESTAMP DEFAULT NOW()
+      );
+
+      INSERT INTO stock_analysis_log
+          (ticker, action, confidence, current_price, day_change_pct, rsi_14d, rationale, risk_profile)
+      SELECT
+          r->>'ticker',
+          r->>'action',
+          (r->>'confidence')::numeric,
+          (s->>'current_price')::numeric,
+          (s->>'day_change_pct')::numeric,
+          (s->>'rsi_14d')::numeric,
+          r->>'rationale',
+          '{{ inputs.risk_profile }}'
+      FROM json_array_elements('{{ outputs.generate_ai_analysis.choices[0].message.content | json | jq(".recommendations") | first | json }}'::json) AS r
+      JOIN json_array_elements('{{ outputs.prepare_analysis_data.vars.stocks | json }}'::json) AS s
+        ON r->>'ticker' = s->>'ticker';
+
+  - id: send_alerts
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    messageText: |
+      :chart_with_upwards_trend: *Daily Stock Analysis — {{ now() | date('yyyy-MM-dd') }}*
+      _{{ inputs.risk_profile | title }} profile · {{ inputs.analysis_horizon }}_
+
+      *Market Summary:*
+      {{ outputs.generate_ai_analysis.choices[0].message.content | json | jq(".market_summary") | first }}
+
+      *Recommendations ({{ outputs.prepare_analysis_data.vars.count }} stocks analyzed):*
+      {{ outputs.generate_ai_analysis.choices[0].message.content | json | jq('[.recommendations[] | "• " + .ticker + " → " + .action + " (" + (.confidence * 100 | floor | tostring) + "% conf): " + .rationale] | join("\n")') | first }}
+
+      _⚠️ For informational purposes only — not financial advice._
+
+pluginDefaults:
+  - type: io.kestra.plugin.jdbc.postgresql.Queries
+    values:
+      url: "{{ secret('POSTGRES_URL') }}"
+      username: "{{ secret('POSTGRES_USER') }}"
+      password: "{{ secret('POSTGRES_PASSWORD') }}"
+
+triggers:
+  - id: market_open_daily
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 14 * * 1-5"
+    description: Run Monday–Friday at 14:00 UTC (09:00 ET market open) for daily pre-market analysis
+
+extend:
+  title: AI-Powered Stock Watchlist Analysis with Daily Alerts and PostgreSQL Logging
+  shortDescription: "This blueprint fetches 30-day price history for a configurable stock watchlist via Yahoo Finance, computes momentum and RSI indicators, uses OpenAI GPT-4o to generate risk-calibrated buy/sell/hold recommendations, logs all signals to PostgreSQL, and delivers a daily briefing to Slack."
+  description: |
+    This blueprint **fetches 30-day price history for a configurable stock watchlist**,
+    computes key technical indicators (momentum, RSI), uses **OpenAI GPT-4o** to generate
+    risk-calibrated buy/sell/hold/watch recommendations, **logs all signals to PostgreSQL**
+    for tracking and backtesting, and delivers a formatted daily briefing to **Slack** every
+    weekday morning before market open.
+
+    It demonstrates how to:
+
+    1. Fetch **30 days of OHLC price data** for multiple tickers in parallel from the Yahoo
+       Finance API, using `ForEach` with bounded concurrency to avoid rate limiting.
+    2. Compute **technical indicators in Python**: daily and monthly price change percentages,
+       a 14-day RSI approximation, and proximity to 52-week highs/lows — providing the AI
+       with quantitative signals rather than raw data.
+    3. Send enriched market data to **GPT-4o with structured JSON output** to generate
+       actionable recommendations (BUY/HOLD/SELL/WATCH) with confidence scores and rationale,
+       calibrated to a configurable risk profile (conservative/moderate/aggressive).
+    4. **Append all recommendations to PostgreSQL** for historical tracking, enabling
+       win-rate analysis and strategy backtesting against actual market outcomes.
+    5. Post a formatted **Slack digest** every weekday at market open with the market summary,
+       per-ticker recommendations, confidence scores, and key reasoning.
+
+    This pattern is ideal for:
+      - **Quantitative analysts and traders** who want AI to augment — not replace — their
+        technical analysis workflow with a systematic daily signal
+      - **Portfolio managers** tracking a specific watchlist and wanting structured alerts
+        before making intraday decisions
+      - **Algorithmic trading teams** building a signal logging layer before adding an
+        automated execution step
+      - **Finance enthusiasts and students** learning to combine technical indicators
+        with LLM-based reasoning for market analysis
+
+    The flow can be extended to add a human-approval gate before any automated trade execution,
+    integrate with broker APIs (Alpaca, Interactive Brokers) for paper trading, add fundamental
+    data (P/E, earnings dates) via Financial Modeling Prep or Alpha Vantage, or implement
+    portfolio-level position sizing logic based on confidence scores.
+  tags:
+    - AI
+    - Business
+  ee: false
+  demo: false
+  meta_description: |
+    Automate daily stock watchlist analysis with Kestra and OpenAI GPT-4o. Fetches Yahoo Finance
+    price data, computes RSI and momentum indicators, generates risk-calibrated buy/sell/hold
+    recommendations, logs to PostgreSQL, and delivers weekday morning alerts to Slack.

--- a/flows/ai-stock-analysis-alerts.yaml
+++ b/flows/ai-stock-analysis-alerts.yaml
@@ -215,6 +215,7 @@ triggers:
 
 extend:
   title: AI-Powered Stock Watchlist Analysis with Daily Alerts and PostgreSQL Logging
+  metaTitle: AI Stock Watchlist Analysis with Alerts
   shortDescription: "This blueprint fetches 30-day price history for a configurable stock watchlist via Yahoo Finance, computes momentum and RSI indicators, uses OpenAI GPT-4o to generate risk-calibrated buy/sell/hold recommendations, logs all signals to PostgreSQL, and delivers a daily briefing to Slack."
   description: |
     This blueprint **fetches 30-day price history for a configurable stock watchlist**,
@@ -257,7 +258,4 @@ extend:
     - Business
   ee: false
   demo: false
-  meta_description: |
-    Automate daily stock watchlist analysis with Kestra and OpenAI GPT-4o. Fetches Yahoo Finance
-    price data, computes RSI and momentum indicators, generates risk-calibrated buy/sell/hold
-    recommendations, logs to PostgreSQL, and delivers weekday morning alerts to Slack.
+  metaDescription: Automate daily stock analysis with Kestra and OpenAI GPT-4o. Fetches Yahoo Finance data, computes technical indicators, and delivers buy/sell/hold alerts to Slack.

--- a/flows/ai-text-to-sql-openai.yaml
+++ b/flows/ai-text-to-sql-openai.yaml
@@ -1,0 +1,105 @@
+id: ai-text-to-sql-openai
+namespace: company.team
+
+inputs:
+  - id: question
+    type: STRING
+    displayName: Database question
+    description: Ask a question in natural language to query your database
+    defaults: "List all tables and their column names"
+
+tasks:
+  - id: fetch_schema
+    type: io.kestra.plugin.jdbc.postgresql.Queries
+    fetchType: FETCH
+    sql: |
+      SELECT
+        table_name,
+        string_agg(column_name || ' (' || data_type || ')', ', ' ORDER BY ordinal_position) AS columns
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      GROUP BY table_name
+      ORDER BY table_name
+
+  - id: generate_sql
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o
+    maxTokens: 500
+    messages:
+      - role: system
+        content: |
+          You are an expert PostgreSQL assistant. Given the following database schema, generate
+          a valid SQL SELECT query to answer the user's question. The AI receives only the schema —
+          never the actual data — to preserve data privacy.
+
+          Database schema (table_name: columns):
+          {{ outputs.fetch_schema.rows | json }}
+
+          Rules:
+          - Only use tables and columns present in the schema above
+          - Output a raw SQL SELECT statement only — no markdown, no backticks, no explanations
+          - If the question cannot be answered with SQL, output: NO_SQL: <reason>
+      - role: user
+        content: "{{ inputs.question }}"
+
+  - id: check_sql
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.generate_sql.choices[0].message.content | startsWith('NO_SQL') == false }}"
+    then:
+      - id: execute_query
+        type: io.kestra.plugin.jdbc.postgresql.Queries
+        fetchType: FETCH
+        sql: "{{ outputs.generate_sql.choices[0].message.content }}"
+
+      - id: format_results
+        type: io.kestra.plugin.serdes.json.IonToJson
+        from: "{{ outputs.execute_query.outputs[0].uri }}"
+        newLine: false
+    else:
+      - id: log_no_sql
+        type: io.kestra.plugin.core.log.Log
+        message: "{{ outputs.generate_sql.choices[0].message.content }}"
+
+pluginDefaults:
+  - type: io.kestra.plugin.jdbc.postgresql.Queries
+    values:
+      url: "{{ secret('POSTGRES_URL') }}"
+      username: "{{ secret('POSTGRES_USER') }}"
+      password: "{{ secret('POSTGRES_PASSWORD') }}"
+
+extend:
+  title: Generate and Execute SQL Queries from Natural Language Using OpenAI GPT-4o
+  shortDescription: "This blueprint shows how to build a privacy-preserving text-to-SQL pipeline where an AI model generates queries from database schema alone — never from the actual data."
+  description: |
+    This blueprint shows how to build a **privacy-preserving text-to-SQL pipeline** where
+    an AI model generates queries from the **database schema alone** — never from the actual data.
+
+    It demonstrates how to:
+
+    1. Introspect a **PostgreSQL database schema** at runtime using the `information_schema`
+       catalog, extracting table names and column definitions without touching any row data.
+    2. Pass the schema structure and a **natural language question** to **OpenAI GPT-4o**,
+       which generates a valid SQL SELECT statement grounded solely in the schema.
+    3. Conditionally execute the generated query against the database only when a SQL statement
+       was produced — invalid or unanswerable questions are logged instead.
+    4. Return the query results as structured JSON for downstream processing, reporting, or display.
+
+    This approach is ideal for:
+      - Teams that need **AI-powered data exploration** without exposing sensitive records to LLMs
+      - Internal analytics tools where non-technical users query production databases in plain English
+      - Compliance-sensitive environments where data privacy rules prohibit sending actual rows to AI APIs
+      - Rapid prototyping of natural-language interfaces over existing databases
+
+    The flow can be extended to support multiple schemas, add result caching with the KV store,
+    route queries to different databases based on the question, or chain into downstream reporting
+    and notification tasks.
+  tags:
+    - AI
+    - Data
+  ee: false
+  demo: false
+  meta_description: |
+    Build a privacy-preserving text-to-SQL pipeline with Kestra and OpenAI GPT-4o. The AI
+    generates SQL queries from the database schema only — never from actual data — then executes
+    them and returns results as structured JSON.

--- a/flows/ai-text-to-sql-openai.yaml
+++ b/flows/ai-text-to-sql-openai.yaml
@@ -70,6 +70,7 @@ pluginDefaults:
 
 extend:
   title: Generate and Execute SQL Queries from Natural Language Using OpenAI GPT-4o
+  metaTitle: Text-to-SQL with OpenAI GPT-4o
   shortDescription: "This blueprint shows how to build a privacy-preserving text-to-SQL pipeline where an AI model generates queries from database schema alone — never from the actual data."
   description: |
     This blueprint shows how to build a **privacy-preserving text-to-SQL pipeline** where
@@ -99,7 +100,4 @@ extend:
     - Data
   ee: false
   demo: false
-  meta_description: |
-    Build a privacy-preserving text-to-SQL pipeline with Kestra and OpenAI GPT-4o. The AI
-    generates SQL queries from the database schema only — never from actual data — then executes
-    them and returns results as structured JSON.
+  metaDescription: Build a privacy-preserving text-to-SQL pipeline with Kestra and OpenAI GPT-4o. Generates SQL from schema only, executes queries, and returns structured JSON.

--- a/flows/csv-url-to-postgres.yaml
+++ b/flows/csv-url-to-postgres.yaml
@@ -46,6 +46,7 @@ tasks:
 
 extend:
   title: Download a CSV from a URL and Bulk-Load It into PostgreSQL with COPY
+  metaTitle: Bulk-Load CSV into PostgreSQL with COPY
   shortDescription: "This blueprint downloads a CSV file from any public URL, parses it through Kestra's serialization layer, and bulk-loads it into a PostgreSQL table using the fast COPY protocol."
   description: |
     This blueprint **downloads a CSV file from any public URL, parses it through Kestra's
@@ -78,7 +79,4 @@ extend:
     - Core
   ee: false
   demo: false
-  meta_description: |
-    Download a CSV from any public URL and bulk-load it into PostgreSQL using Kestra's COPY IN plugin.
-    Parses through the ION serialization layer for type normalization and ingests millions of rows
-    efficiently without row-by-row inserts.
+  metaDescription: Download a CSV from any URL and bulk-load it into PostgreSQL using Kestra's COPY IN plugin. Ingests millions of rows efficiently without row-by-row inserts.

--- a/flows/csv-url-to-postgres.yaml
+++ b/flows/csv-url-to-postgres.yaml
@@ -1,0 +1,84 @@
+id: csv-url-to-postgres
+namespace: company.team
+
+inputs:
+  - id: csv_url
+    type: STRING
+    displayName: CSV file URL
+    description: Public URL of the CSV file to download and load into PostgreSQL
+    defaults: "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv"
+  - id: target_table
+    type: STRING
+    displayName: Target table name
+    description: PostgreSQL table to load data into (must already exist)
+    defaults: "public.raw_data"
+  - id: field_separator
+    type: STRING
+    displayName: Field separator
+    description: The character used to separate columns in the CSV (default comma)
+    defaults: ","
+
+tasks:
+  - id: download_csv
+    type: io.kestra.plugin.core.http.Download
+    uri: "{{ inputs.csv_url }}"
+
+  - id: csv_to_ion
+    type: io.kestra.plugin.serdes.csv.CsvToIon
+    from: "{{ outputs.download_csv.uri }}"
+    fieldSeparator: "{{ inputs.field_separator }}"
+    header: true
+
+  - id: ion_to_csv
+    type: io.kestra.plugin.serdes.csv.IonToCsv
+    from: "{{ outputs.csv_to_ion.uri }}"
+    header: true
+
+  - id: load_to_postgres
+    type: io.kestra.plugin.jdbc.postgresql.CopyIn
+    url: "{{ secret('POSTGRES_URL') }}"
+    username: "{{ secret('POSTGRES_USER') }}"
+    password: "{{ secret('POSTGRES_PASSWORD') }}"
+    from: "{{ outputs.ion_to_csv.uri }}"
+    table: "{{ inputs.target_table }}"
+    format: CSV
+    header: true
+
+extend:
+  title: Download a CSV from a URL and Bulk-Load It into PostgreSQL with COPY
+  shortDescription: "This blueprint downloads a CSV file from any public URL, parses it through Kestra's serialization layer, and bulk-loads it into a PostgreSQL table using the fast COPY protocol."
+  description: |
+    This blueprint **downloads a CSV file from any public URL, parses it through Kestra's
+    serialization layer, and bulk-loads it into a PostgreSQL table** using the native
+    `COPY` protocol — the fastest way to ingest large CSV datasets into Postgres.
+
+    It demonstrates how to:
+
+    1. Download a CSV file from a remote URL using the **HTTP Download** plugin, storing it
+       in Kestra's internal storage for reliable, stateless processing.
+    2. Parse the raw CSV into **Kestra's ION format** — a typed, row-oriented intermediate
+       format that normalizes data types across the pipeline regardless of source encoding.
+    3. Re-serialize the ION data back to a clean, normalized CSV ready for the PostgreSQL
+       bulk loader.
+    4. Use the **PostgreSQL COPY IN** plugin to stream the file directly into the target table
+       using the highly efficient `COPY FROM STDIN` protocol — bypassing row-by-row INSERT
+       overhead and handling millions of rows in seconds.
+
+    This pattern is ideal for:
+      - **Daily data ingestion** from public datasets, partner exports, or data vendor dumps
+      - **ELT pipelines** where raw CSV data is loaded first, then transformed with SQL or dbt
+      - **One-time migrations** from spreadsheet-based workflows to relational databases
+      - Teams replacing manual upload scripts with a reproducible, observable pipeline
+
+    The flow can be extended to add column mapping with a Python transform step, run `CREATE TABLE IF NOT EXISTS`
+    before loading, send a Slack notification with row count on success, or chain into a dbt
+    transformation run after ingestion.
+  tags:
+    - Data
+    - Core
+  ee: false
+  demo: false
+  meta_description: |
+    Download a CSV from any public URL and bulk-load it into PostgreSQL using Kestra's COPY IN plugin.
+    Parses through the ION serialization layer for type normalization and ingests millions of rows
+    efficiently without row-by-row inserts.

--- a/flows/git-backup-flows-to-github.yaml
+++ b/flows/git-backup-flows-to-github.yaml
@@ -1,0 +1,70 @@
+id: git-backup-flows-to-github
+namespace: company.team
+
+inputs:
+  - id: source_namespace
+    type: STRING
+    displayName: Source namespace
+    description: The Kestra namespace whose flows will be backed up
+    defaults: "company.team"
+  - id: git_directory
+    type: STRING
+    displayName: Target directory in Git repository
+    description: Relative path inside the repository where flows will be stored
+    defaults: "kestra-flows"
+
+tasks:
+  - id: push_flows
+    type: io.kestra.plugin.git.PushFlows
+    url: "{{ secret('GITHUB_REPO_URL') }}"
+    username: "{{ secret('GITHUB_USERNAME') }}"
+    password: "{{ secret('GITHUB_TOKEN') }}"
+    branch: main
+    sourceNamespace: "{{ inputs.source_namespace }}"
+    gitDirectory: "{{ inputs.git_directory }}"
+    includeChildNamespaces: true
+    commitMessage: "chore: automated Kestra flow backup — {{ now() | date('yyyy-MM-dd HH:mm') }}"
+    authorName: "Kestra Automation"
+    authorEmail: "{{ secret('GITHUB_AUTHOR_EMAIL') }}"
+
+triggers:
+  - id: daily_backup
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * *"
+    description: Runs every day at 02:00 UTC
+
+extend:
+  title: Automatically Back Up Kestra Flows to a GitHub Repository on a Daily Schedule
+  shortDescription: "This blueprint automates daily version-controlled backups of all Kestra flows in a namespace by pushing them to a GitHub repository, enabling disaster recovery and full change history."
+  description: |
+    This blueprint **automates daily version-controlled backups** of all Kestra flows in a
+    namespace by pushing them as YAML files to a **GitHub repository**, ensuring every change
+    is tracked, recoverable, and auditable.
+
+    It demonstrates how to:
+
+    1. Trigger a backup automatically on a **daily cron schedule** at 02:00 UTC.
+    2. Push all flows from a configurable source namespace — including child namespaces — to a
+       target directory in a Git repository using the native **Kestra Git plugin**.
+    3. Stamp each commit with a human-readable timestamp so the backup history is immediately
+       searchable and understandable.
+    4. Configure the backup target namespace and directory via **flow inputs**, making the
+       blueprint reusable across multiple environments (dev, staging, prod) without code changes.
+
+    This pattern is ideal for:
+      - **Platform engineering teams** that enforce GitOps practices and want flows under source control
+      - **Disaster recovery** scenarios where a repository copy ensures flows can be re-imported quickly
+      - **Compliance and auditing** requirements where every flow change must be logged and attributed
+      - **Multi-environment setups** where dev/staging flows are periodically snapshotted for review
+
+    The flow can be extended to trigger on execution failures, send a Slack notification after each
+    successful backup, or use a webhook trigger to run on-demand in addition to the schedule.
+  tags:
+    - DevOps
+    - Core
+  ee: false
+  demo: false
+  meta_description: |
+    Automatically back up all Kestra flows in a namespace to a GitHub repository on a daily schedule.
+    Uses the native Git plugin to push versioned YAML snapshots with timestamped commits for full
+    disaster recovery and audit trail support.

--- a/flows/git-backup-flows-to-github.yaml
+++ b/flows/git-backup-flows-to-github.yaml
@@ -35,6 +35,7 @@ triggers:
 
 extend:
   title: Automatically Back Up Kestra Flows to a GitHub Repository on a Daily Schedule
+  metaTitle: Back Up Kestra Flows to GitHub Daily
   shortDescription: "This blueprint automates daily version-controlled backups of all Kestra flows in a namespace by pushing them to a GitHub repository, enabling disaster recovery and full change history."
   description: |
     This blueprint **automates daily version-controlled backups** of all Kestra flows in a
@@ -64,7 +65,4 @@ extend:
     - Core
   ee: false
   demo: false
-  meta_description: |
-    Automatically back up all Kestra flows in a namespace to a GitHub repository on a daily schedule.
-    Uses the native Git plugin to push versioned YAML snapshots with timestamped commits for full
-    disaster recovery and audit trail support.
+  metaDescription: Back up Kestra flows to a GitHub repository on a daily schedule. Uses the Git plugin to push versioned YAML snapshots with timestamped commits.

--- a/flows/git-backup-flows-to-github.yaml
+++ b/flows/git-backup-flows-to-github.yaml
@@ -61,7 +61,7 @@ extend:
     The flow can be extended to trigger on execution failures, send a Slack notification after each
     successful backup, or use a webhook trigger to run on-demand in addition to the schedule.
   tags:
-    - DevOps
+    - System
     - Core
   ee: false
   demo: false

--- a/flows/github-star-slack-notification.yaml
+++ b/flows/github-star-slack-notification.yaml
@@ -1,5 +1,6 @@
 extend:
   title: Send GitHub Star Notifications to Slack
+  metaTitle: GitHub Star Notifications to Slack
   shortDescription: Notify your team in Slack whenever a GitHub repository is starred or unstarred
   description: |
     **Listens for GitHub star/unstar webhooks and sends a colour-coded Slack message with the sender
@@ -22,7 +23,7 @@ extend:
     - Webhooks
   ee: false
   demo: false
-  meta_description: Receive GitHub star webhook events and send conditional Slack notifications when a repository is starred or unstarred.
+  metaDescription: Receive GitHub star webhook events and send conditional Slack notifications when a repository is starred or unstarred.
 
 id: github-star-slack-notification
 namespace: company.team

--- a/flows/github-star-slack-notification.yaml
+++ b/flows/github-star-slack-notification.yaml
@@ -16,11 +16,8 @@ extend:
     - **Open-source maintainers** who want real-time awareness of repository traction without polling the GitHub API
     - **DevOps teams** tracking community engagement metrics across internal or public projects
   tags:
-    - GitHub
-    - Slack
-    - DevOps
-    - Notifications
-    - Webhooks
+    - Business
+    - Core
   ee: false
   demo: false
   metaDescription: Receive GitHub star webhook events and send conditional Slack notifications when a repository is starred or unstarred.

--- a/flows/github-star-slack-notification.yaml
+++ b/flows/github-star-slack-notification.yaml
@@ -1,0 +1,70 @@
+extend:
+  title: Send GitHub Star Notifications to Slack
+  shortDescription: Notify your team in Slack whenever a GitHub repository is starred or unstarred
+  description: |
+    **Listens for GitHub star/unstar webhooks and sends a colour-coded Slack message with the sender
+    details and current star count.**
+
+    1. Webhook trigger receives the GitHub star event payload.
+    2. If task inspects the `action` field — `created` (new star) routes to the green notification,
+       `deleted` (unstar) routes to the red notification.
+    3. SlackIncomingWebhook sends an attachment with the sender's login, profile link, and updated
+       repository star count.
+
+    Ideal for:
+    - **Open-source maintainers** who want real-time awareness of repository traction without polling the GitHub API
+    - **DevOps teams** tracking community engagement metrics across internal or public projects
+  tags:
+    - GitHub
+    - Slack
+    - DevOps
+    - Notifications
+    - Webhooks
+  ee: false
+  demo: false
+  meta_description: Receive GitHub star webhook events and send conditional Slack notifications when a repository is starred or unstarred.
+
+id: github-star-slack-notification
+namespace: company.team
+
+tasks:
+  - id: check_action
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ trigger.body.action == 'created' }}"
+    then:
+      - id: notify_star_added
+        type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "channel": "#general",
+            "attachments": [
+              {
+                "title": "Got new star from: {{ trigger.body.sender.login }}",
+                "title_link": "{{ trigger.body.sender.html_url }}",
+                "text": "The project now has {{ trigger.body.repository.stargazers_count }} stars",
+                "color": "#88FF00"
+              }
+            ]
+          }
+    else:
+      - id: notify_star_removed
+        type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "channel": "#general",
+            "attachments": [
+              {
+                "title": "Star removed by: {{ trigger.body.sender.login }}",
+                "title_link": "{{ trigger.body.sender.html_url }}",
+                "text": "The project now has {{ trigger.body.repository.stargazers_count }} stars",
+                "color": "#FF0000"
+              }
+            ]
+          }
+
+triggers:
+  - id: github_webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "{{ secret('GITHUB_WEBHOOK_KEY') }}"

--- a/flows/google-sheets-to-mailchimp-sync.yaml
+++ b/flows/google-sheets-to-mailchimp-sync.yaml
@@ -1,5 +1,6 @@
 extend:
   title: Sync Google Sheets Leads to a Mailchimp Subscriber List
+  metaTitle: Google Sheets to Mailchimp Sync
   shortDescription: Read rows from a Google Sheet every 2 minutes and subscribe each email to a Mailchimp list
   description: |
     **Reads a Google Sheets range on a schedule and subscribes each row's email address to a
@@ -24,7 +25,7 @@ extend:
     - Sync
   ee: false
   demo: false
-  meta_description: Periodically read email rows from a Google Sheet and subscribe each address to a Mailchimp list using Kestra's HTTP and ForEach plugins.
+  metaDescription: Periodically read email rows from a Google Sheet and subscribe each address to a Mailchimp list using Kestra's HTTP and ForEach plugins.
 
 id: google-sheets-to-mailchimp-sync
 namespace: company.team

--- a/flows/google-sheets-to-mailchimp-sync.yaml
+++ b/flows/google-sheets-to-mailchimp-sync.yaml
@@ -18,11 +18,8 @@ extend:
       continuously to an email campaign list without manual CSV imports
     - **Sales operations** replacing one-off list uploads with a near-real-time sync pipeline
   tags:
-    - Google Sheets
-    - Mailchimp
-    - Lead Generation
-    - Marketing Automation
-    - Sync
+    - Business
+    - Data
   ee: false
   demo: false
   metaDescription: Periodically read email rows from a Google Sheet and subscribe each address to a Mailchimp list using Kestra's HTTP and ForEach plugins.

--- a/flows/google-sheets-to-mailchimp-sync.yaml
+++ b/flows/google-sheets-to-mailchimp-sync.yaml
@@ -1,0 +1,90 @@
+extend:
+  title: Sync Google Sheets Leads to a Mailchimp Subscriber List
+  shortDescription: Read rows from a Google Sheet every 2 minutes and subscribe each email to a Mailchimp list
+  description: |
+    **Reads a Google Sheets range on a schedule and subscribes each row's email address to a
+    Mailchimp audience list.**
+
+    1. Schedule trigger fires every 2 minutes to process new rows.
+    2. Google Sheets API HTTP request fetches all data from the configured spreadsheet range.
+    3. Python Script parses the JSON response, skips the header row, and extracts valid email
+       addresses from the first column.
+    4. ForEach loop iterates each email and sends an HTTP POST to the Mailchimp Members API to
+       subscribe it to the configured list.
+
+    Ideal for:
+    - **Marketing teams** capturing inbound leads in a shared spreadsheet and pushing them
+      continuously to an email campaign list without manual CSV imports
+    - **Sales operations** replacing one-off list uploads with a near-real-time sync pipeline
+  tags:
+    - Google Sheets
+    - Mailchimp
+    - Lead Generation
+    - Marketing Automation
+    - Sync
+  ee: false
+  demo: false
+  meta_description: Periodically read email rows from a Google Sheet and subscribe each address to a Mailchimp list using Kestra's HTTP and ForEach plugins.
+
+id: google-sheets-to-mailchimp-sync
+namespace: company.team
+
+inputs:
+  - id: sheet_id
+    type: STRING
+    displayName: Google Sheet ID
+    description: The spreadsheet ID from the Google Sheets URL (between /d/ and /edit)
+  - id: sheet_range
+    type: STRING
+    displayName: Sheet Range
+    description: A1 notation range to read, e.g. Sheet1!A:C
+    defaults: "Sheet1!A:C"
+  - id: mailchimp_list_id
+    type: STRING
+    displayName: Mailchimp Audience ID
+    description: The Mailchimp audience (list) ID to subscribe contacts to
+  - id: mailchimp_datacenter
+    type: STRING
+    displayName: Mailchimp Datacenter
+    description: Datacenter prefix from your Mailchimp API key, e.g. us1, us14
+    defaults: "us1"
+
+tasks:
+  - id: read_google_sheets
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://sheets.googleapis.com/v4/spreadsheets/{{ inputs.sheet_id }}/values/{{ inputs.sheet_range }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('GOOGLE_OAUTH_TOKEN') }}"
+
+  - id: parse_rows
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import json
+      from kestra import Kestra
+
+      body = json.loads("""{{ outputs.read_google_sheets.body }}""")
+      rows = body.get("values", [])
+      # Skip header row; keep only rows with a valid email in column A
+      emails = [row[0] for row in rows[1:] if row and "@" in row[0]]
+      Kestra.outputs({"emails": json.dumps(emails)})
+
+  - id: subscribe_emails
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ outputs.parse_rows.vars.emails }}"
+    concurrencyLimit: 5
+    tasks:
+      - id: add_to_mailchimp
+        type: io.kestra.plugin.core.http.Request
+        uri: "https://{{ inputs.mailchimp_datacenter }}.api.mailchimp.com/3.0/lists/{{ inputs.mailchimp_list_id }}/members"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ secret('MAILCHIMP_API_KEY') }}"
+          Content-Type: "application/json"
+        body: |
+          {"email_address": "{{ taskrun.value }}", "status": "subscribed"}
+
+triggers:
+  - id: every_two_minutes
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/2 * * * *"

--- a/flows/hackernews-etl-to-postgres.yaml
+++ b/flows/hackernews-etl-to-postgres.yaml
@@ -165,6 +165,7 @@ triggers:
 
 extend:
   title: Extract, Transform, and Store HackerNews Top Stories with AI-Generated Daily Digest
+  metaTitle: HackerNews ETL with AI Daily Digest
   shortDescription: "This blueprint fetches trending HackerNews stories via the public Firebase API, normalizes and enriches the data, stores it in PostgreSQL, uses OpenAI to generate a trend digest, and posts the summary to Slack — running daily as a fully automated tech intelligence pipeline."
   description: |
     This blueprint **fetches trending HackerNews stories via the public Firebase API**,
@@ -202,7 +203,4 @@ extend:
     - Business
   ee: false
   demo: true
-  meta_description: |
-    Automate HackerNews tech intelligence with Kestra. Fetches top stories via the Firebase API,
-    stores them in PostgreSQL, generates an AI-powered trend digest with GPT-4o-mini, and posts
-    a daily briefing to Slack — all on a fully automated schedule.
+  metaDescription: Fetch HackerNews top stories with Kestra, store in PostgreSQL, generate an AI-powered trend digest with GPT-4o-mini, and post a daily briefing to Slack.

--- a/flows/hackernews-etl-to-postgres.yaml
+++ b/flows/hackernews-etl-to-postgres.yaml
@@ -1,0 +1,208 @@
+id: hackernews-etl-to-postgres
+namespace: company.team
+
+inputs:
+  - id: story_type
+    type: SELECT
+    displayName: Story type
+    description: Which HackerNews feed to fetch stories from
+    values:
+      - topstories
+      - newstories
+      - beststories
+    defaults: "topstories"
+  - id: max_stories
+    type: INT
+    displayName: Number of stories
+    description: How many stories to fetch and process (max 30)
+    defaults: 10
+
+tasks:
+  - id: fetch_story_ids
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://hacker-news.firebaseio.com/v0/{{ inputs.story_type }}.json"
+    method: GET
+
+  - id: fetch_stories
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ outputs.fetch_story_ids.body | json | jq('.[0:' + inputs.max_stories | string + ']') | first }}"
+    concurrencyLimit: 5
+    tasks:
+      - id: fetch_story_detail
+        type: io.kestra.plugin.core.http.Request
+        uri: "https://hacker-news.firebaseio.com/v0/item/{{ taskrun.value }}.json"
+        method: GET
+
+  - id: summarize_stories
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      stories_raw.json: "{{ outputs.fetch_stories | json }}"
+    dependencies:
+      - requests
+    script: |
+      import json
+      from kestra import Kestra
+
+      with open("stories_raw.json") as f:
+          raw = json.load(f)
+
+      stories = []
+      for story_id, story_outputs in raw.items():
+          body = story_outputs.get("body", "{}")
+          if isinstance(body, str):
+              try:
+                  story = json.loads(body)
+              except:
+                  continue
+          else:
+              story = body
+
+          if not story or story.get("type") not in ("story", "job", "ask", "show"):
+              continue
+
+          stories.append({
+              "id": story.get("id"),
+              "title": story.get("title", ""),
+              "url": story.get("url", ""),
+              "score": story.get("score", 0),
+              "author": story.get("by", ""),
+              "comments": story.get("descendants", 0),
+              "story_type": story.get("type", ""),
+              "posted_at": story.get("time", 0)
+          })
+
+      # Sort by score descending
+      stories.sort(key=lambda x: x["score"], reverse=True)
+      Kestra.outputs({"stories": stories, "count": len(stories)})
+
+  - id: summarize_with_ai
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4o-mini
+    maxTokens: 800
+    messages:
+      - role: system
+        content: |
+          You are a tech analyst. Given a list of trending HackerNews stories, write a brief digest
+          (3-5 bullet points) highlighting the most interesting themes and trends. Be concise and insightful.
+          Focus on what these stories collectively reveal about the current state of tech.
+      - role: user
+        content: |
+          HackerNews {{ inputs.story_type }} today:
+          {{ outputs.summarize_stories.vars.stories | json }}
+
+  - id: store_to_postgres
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      stories.json: "{{ outputs.summarize_stories.vars.stories | json }}"
+    script: |
+      import json
+      import psycopg2
+      import os
+
+      with open("stories.json") as f:
+          stories = json.load(f)
+
+      conn = psycopg2.connect(
+          host=os.getenv("POSTGRES_HOST", ""),
+          dbname=os.getenv("POSTGRES_DB", ""),
+          user=os.getenv("POSTGRES_USER_VAL", ""),
+          password=os.getenv("POSTGRES_PASS_VAL", ""),
+          port=5432
+      )
+      cur = conn.cursor()
+
+      cur.execute("""
+          CREATE TABLE IF NOT EXISTS hackernews_stories (
+              id BIGINT PRIMARY KEY,
+              title TEXT,
+              url TEXT,
+              score INTEGER,
+              author TEXT,
+              comments INTEGER,
+              story_type TEXT,
+              posted_at BIGINT,
+              fetched_at TIMESTAMP DEFAULT NOW()
+          )
+      """)
+
+      for story in stories:
+          cur.execute("""
+              INSERT INTO hackernews_stories (id, title, url, score, author, comments, story_type, posted_at)
+              VALUES (%(id)s, %(title)s, %(url)s, %(score)s, %(author)s, %(comments)s, %(story_type)s, %(posted_at)s)
+              ON CONFLICT (id) DO UPDATE SET
+                  score = EXCLUDED.score,
+                  comments = EXCLUDED.comments,
+                  fetched_at = NOW()
+          """, story)
+
+      conn.commit()
+      cur.close()
+      conn.close()
+      print(f"Stored {len(stories)} stories to PostgreSQL")
+    env:
+      POSTGRES_HOST: "{{ secret('POSTGRES_HOST') }}"
+      POSTGRES_DB: "{{ secret('POSTGRES_DB') }}"
+      POSTGRES_USER_VAL: "{{ secret('POSTGRES_USER') }}"
+      POSTGRES_PASS_VAL: "{{ secret('POSTGRES_PASSWORD') }}"
+    dependencies:
+      - psycopg2-binary
+
+  - id: post_digest_to_slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    messageText: |
+      :newspaper: *HackerNews {{ inputs.story_type | replace('stories', '') | title }} Digest*
+      _{{ outputs.summarize_stories.vars.count }} stories processed_
+
+      {{ outputs.summarize_with_ai.choices[0].message.content }}
+
+triggers:
+  - id: daily_digest
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 8 * * *"
+    description: Fetch and process HackerNews stories every day at 08:00 UTC
+
+extend:
+  title: Extract, Transform, and Store HackerNews Top Stories with AI-Generated Daily Digest
+  shortDescription: "This blueprint fetches trending HackerNews stories via the public Firebase API, normalizes and enriches the data, stores it in PostgreSQL, uses OpenAI to generate a trend digest, and posts the summary to Slack — running daily as a fully automated tech intelligence pipeline."
+  description: |
+    This blueprint **fetches trending HackerNews stories via the public Firebase API**,
+    normalizes and enriches the data, stores it in **PostgreSQL**, uses **OpenAI** to
+    generate a trend digest, and posts the summary to **Slack** — running daily as a
+    fully automated tech intelligence pipeline.
+
+    It demonstrates how to:
+
+    1. Fetch story IDs from the HackerNews public API (top, new, or best stories) and
+       retrieve full story details for the top N stories in parallel using **ForEach**.
+    2. Parse and normalize the raw Firebase API response in Python, extracting title,
+       URL, score, author, comment count, and publication timestamp.
+    3. Send the story list to **OpenAI GPT-4o-mini** to generate a concise **3-5 bullet
+       tech digest** highlighting the themes and trends revealed by the day's top stories.
+    4. **Upsert all stories to PostgreSQL** using `INSERT ... ON CONFLICT DO UPDATE`
+       to maintain a deduplicated, ever-growing historical archive with each run.
+    5. Post the AI-generated digest to a **Slack channel** for daily team consumption,
+       linking each key theme to actionable engineering or business insight.
+
+    This pattern is ideal for:
+      - **Tech newsletter authors** who want a daily automated briefing on what's trending
+        in the developer community
+      - **Engineering teams** that use HackerNews as a signal for emerging libraries,
+        security vulnerabilities, and industry shifts
+      - **Investors and analysts** monitoring startup and technology momentum
+      - **Content creators** who need a daily spark of inspiration grounded in real community activity
+
+    The flow can be extended to filter stories by keyword, add sentiment analysis, export
+    to Notion or Google Docs, track score trends over time for ranking analysis, or
+    trigger a deeper summarization using the full article content via a web scraper.
+  tags:
+    - Data
+    - AI
+    - Business
+  ee: false
+  demo: true
+  meta_description: |
+    Automate HackerNews tech intelligence with Kestra. Fetches top stories via the Firebase API,
+    stores them in PostgreSQL, generates an AI-powered trend digest with GPT-4o-mini, and posts
+    a daily briefing to Slack — all on a fully automated schedule.

--- a/flows/incident-response-jira-slack.yaml
+++ b/flows/incident-response-jira-slack.yaml
@@ -1,0 +1,196 @@
+id: incident-response-jira-slack
+namespace: company.team
+
+inputs:
+  - id: service
+    type: STRING
+    displayName: Affected service
+    description: Name of the service or system experiencing the incident
+    defaults: "payment-api"
+  - id: severity
+    type: SELECT
+    displayName: Severity
+    description: Incident severity level
+    values:
+      - P1 - Critical
+      - P2 - High
+      - P3 - Medium
+      - P4 - Low
+    defaults: "P2 - High"
+  - id: description
+    type: STRING
+    displayName: Incident description
+    description: Brief description of the incident and its impact
+    defaults: "Service returning 500 errors with elevated error rate above 10%"
+  - id: jira_project_key
+    type: STRING
+    displayName: Jira project key
+    description: The Jira project key to create the incident ticket under
+    defaults: "OPS"
+  - id: slack_channel
+    type: STRING
+    displayName: Slack channel
+    description: Slack channel ID or name to notify the on-call team
+    defaults: "#oncall"
+
+tasks:
+  - id: create_jira_ticket
+    type: io.kestra.plugin.jira.issues.Create
+    baseUrl: "https://{{ secret('JIRA_DOMAIN') }}.atlassian.net"
+    username: "{{ secret('JIRA_USERNAME') }}"
+    password: "{{ secret('JIRA_API_TOKEN') }}"
+    projectKey: "{{ inputs.jira_project_key }}"
+    summary: "[{{ inputs.severity }}] Incident: {{ inputs.service }}"
+    description: |
+      *Incident Report*
+
+      *Service:* {{ inputs.service }}
+      *Severity:* {{ inputs.severity }}
+      *Reported at:* {{ now() | date('yyyy-MM-dd HH:mm:ss') }} UTC
+
+      *Description:*
+      {{ inputs.description }}
+
+      ---
+      _Created automatically by Kestra Incident Response workflow._
+    issueTypeId: "10001"
+    labels:
+      - incident
+      - "{{ inputs.severity | lower | replace(' ', '-') | replace(':', '') }}"
+
+  - id: alert_slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": ":rotating_light: *Incident Alert — {{ inputs.severity }}*",
+        "blocks": [
+          {
+            "type": "header",
+            "text": {
+              "type": "plain_text",
+              "text": ":rotating_light: Incident Alert — {{ inputs.severity }}"
+            }
+          },
+          {
+            "type": "section",
+            "fields": [
+              {"type": "mrkdwn", "text": "*Service:*\n{{ inputs.service }}"},
+              {"type": "mrkdwn", "text": "*Severity:*\n{{ inputs.severity }}"},
+              {"type": "mrkdwn", "text": "*Jira Ticket:*\n{{ outputs.create_jira_ticket.key }}"},
+              {"type": "mrkdwn", "text": "*Reported:*\n{{ now() | date('yyyy-MM-dd HH:mm') }} UTC"}
+            ]
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "*Description:*\n{{ inputs.description }}"
+            }
+          }
+        ]
+      }
+
+  - id: generate_timeline_report
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import json
+      from datetime import datetime
+      from kestra import Kestra
+
+      now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+      jira_key = "{{ outputs.create_jira_ticket.key }}"
+      service = "{{ inputs.service }}"
+      severity = "{{ inputs.severity }}"
+      description = """{{ inputs.description }}"""
+
+      report = f"""INCIDENT TIMELINE REPORT
+      ========================
+      Generated: {now}
+      Jira Ticket: {jira_key}
+
+      SERVICE: {service}
+      SEVERITY: {severity}
+
+      DESCRIPTION:
+      {description}
+
+      TIMELINE:
+      {now} - Incident detected and reported
+      {now} - Jira ticket {jira_key} created
+      {now} - On-call team notified via Slack
+
+      POSTMORTEM PLACEHOLDERS:
+      Root Cause:      [TO BE FILLED]
+      Impact:          [TO BE FILLED]
+      Resolution:      [TO BE FILLED]
+      Resolved At:     [TO BE FILLED]
+      Action Items:    [TO BE FILLED]
+      """
+
+      Kestra.outputs({"report_content": report})
+
+  - id: log_incident_to_postgres
+    type: io.kestra.plugin.jdbc.postgresql.Queries
+    fetchType: NONE
+    sql: |
+      INSERT INTO incident_log (jira_key, service, severity, description, created_at)
+      VALUES (
+        '{{ outputs.create_jira_ticket.key }}',
+        '{{ inputs.service }}',
+        '{{ inputs.severity }}',
+        '{{ inputs.description | replace("'", "''") }}',
+        NOW()
+      )
+      ON CONFLICT (jira_key) DO NOTHING;
+
+pluginDefaults:
+  - type: io.kestra.plugin.jdbc.postgresql.Queries
+    values:
+      url: "{{ secret('POSTGRES_URL') }}"
+      username: "{{ secret('POSTGRES_USER') }}"
+      password: "{{ secret('POSTGRES_PASSWORD') }}"
+
+extend:
+  title: Automate Incident Response — Create Jira Tickets, Alert Slack, and Log to Database
+  shortDescription: "This blueprint automates the full incident response lifecycle by creating a Jira ticket, sending a structured Slack alert to the on-call team, generating an incident timeline report, and logging the incident to a PostgreSQL audit table."
+  description: |
+    This blueprint **automates the full incident response lifecycle** by creating a
+    Jira ticket, sending a **structured Slack alert** to the on-call team, generating an
+    incident timeline report, and logging the incident to a **PostgreSQL audit table** —
+    all triggered by a single flow execution with configurable inputs.
+
+    It demonstrates how to:
+
+    1. Create a **Jira issue** with structured metadata (service name, severity label,
+       description, timestamp) using the Kestra Jira plugin, returning a unique ticket key
+       for cross-system tracking.
+    2. Post a **rich Slack alert** with Block Kit formatting to the on-call channel,
+       embedding the Jira ticket key, severity color, and incident description in a
+       scannable layout.
+    3. Generate an **incident timeline document** in Python, pre-populated with event
+       timestamps and postmortem placeholders ready for the responder to fill in.
+    4. Append an **audit record to PostgreSQL**, building a permanent incident log
+       with Jira key, service, severity, and timestamp for SLA reporting and retrospectives.
+
+    This pattern is ideal for:
+      - **DevOps and SRE teams** that need a reproducible, auditable incident response
+        process invocable from Slack, CI/CD pipelines, or monitoring alerts
+      - **Engineering organizations** building toward incident management maturity with
+        consistent documentation and cross-tool synchronization
+      - **Compliance-sensitive environments** requiring tamper-proof audit logs of all
+        production incidents and their resolution status
+      - Teams replacing manual incident triage with a structured, observable automation
+
+    The flow can be extended to auto-trigger from a monitoring alert webhook, add
+    PagerDuty escalation for P1 incidents, send the timeline report to Google Drive,
+    or chain into a postmortem template generator after the incident is resolved.
+  tags:
+    - DevOps
+    - Business
+  ee: false
+  demo: false
+  meta_description: |
+    Automate incident response with Kestra. Creates a Jira ticket, fires a structured Slack
+    Block Kit alert, generates an incident timeline report with postmortem placeholders,
+    and logs the incident to PostgreSQL for SLA tracking and audit compliance.

--- a/flows/incident-response-jira-slack.yaml
+++ b/flows/incident-response-jira-slack.yaml
@@ -187,7 +187,7 @@ extend:
     PagerDuty escalation for P1 incidents, send the timeline report to Google Drive,
     or chain into a postmortem template generator after the incident is resolved.
   tags:
-    - DevOps
+    - Infrastructure
     - Business
   ee: false
   demo: false

--- a/flows/incident-response-jira-slack.yaml
+++ b/flows/incident-response-jira-slack.yaml
@@ -153,6 +153,7 @@ pluginDefaults:
 
 extend:
   title: Automate Incident Response — Create Jira Tickets, Alert Slack, and Log to Database
+  metaTitle: Automate Incident Response with Jira and Slack
   shortDescription: "This blueprint automates the full incident response lifecycle by creating a Jira ticket, sending a structured Slack alert to the on-call team, generating an incident timeline report, and logging the incident to a PostgreSQL audit table."
   description: |
     This blueprint **automates the full incident response lifecycle** by creating a
@@ -190,7 +191,4 @@ extend:
     - Business
   ee: false
   demo: false
-  meta_description: |
-    Automate incident response with Kestra. Creates a Jira ticket, fires a structured Slack
-    Block Kit alert, generates an incident timeline report with postmortem placeholders,
-    and logs the incident to PostgreSQL for SLA tracking and audit compliance.
+  metaDescription: Automate incident response with Kestra. Creates a Jira ticket, sends a Slack alert, generates an incident timeline, and logs to PostgreSQL for audit.

--- a/flows/postgres-query-executor.yaml
+++ b/flows/postgres-query-executor.yaml
@@ -1,5 +1,6 @@
 extend:
   title: Execute a Parameterised SQL Query on Postgres
+  metaTitle: Execute SQL Queries on Postgres
   shortDescription: Run any SQL query against a Postgres database and store the result rows
   description: |
     **Runs a configurable SQL query against a Postgres database and stores the full result set
@@ -21,7 +22,7 @@ extend:
     - ETL
   ee: false
   demo: false
-  meta_description: Execute a configurable SQL query on a Postgres database and store the full result set using the Kestra JDBC plugin.
+  metaDescription: Execute a configurable SQL query on a Postgres database and store the full result set using the Kestra JDBC plugin.
 
 id: postgres-query-executor
 namespace: company.team

--- a/flows/postgres-query-executor.yaml
+++ b/flows/postgres-query-executor.yaml
@@ -16,10 +16,7 @@ extend:
     - **Database administrators** automating routine health checks or scheduled data extractions
     - **Analytics teams** pulling periodic data snapshots without maintaining custom scripts
   tags:
-    - Postgres
-    - SQL
-    - Database
-    - ETL
+    - Data
   ee: false
   demo: false
   metaDescription: Execute a configurable SQL query on a Postgres database and store the full result set using the Kestra JDBC plugin.

--- a/flows/postgres-query-executor.yaml
+++ b/flows/postgres-query-executor.yaml
@@ -1,0 +1,41 @@
+extend:
+  title: Execute a Parameterised SQL Query on Postgres
+  shortDescription: Run any SQL query against a Postgres database and store the result rows
+  description: |
+    **Runs a configurable SQL query against a Postgres database and stores the full result set
+    for downstream tasks or inspection.**
+
+    1. Flow inputs accept the SQL query text; the database URL is read from a secret.
+    2. Postgres Queries task connects to the database, executes the statement, and stores all
+       result rows using `fetchType: STORE`.
+
+    Ideal for:
+    - **Data engineers** who need a reusable, parameterised query template as a building block
+      in larger ETL pipelines
+    - **Database administrators** automating routine health checks or scheduled data extractions
+    - **Analytics teams** pulling periodic data snapshots without maintaining custom scripts
+  tags:
+    - Postgres
+    - SQL
+    - Database
+    - ETL
+  ee: false
+  demo: false
+  meta_description: Execute a configurable SQL query on a Postgres database and store the full result set using the Kestra JDBC plugin.
+
+id: postgres-query-executor
+namespace: company.team
+
+inputs:
+  - id: query
+    type: STRING
+    displayName: SQL Query
+    description: SQL statement to execute against the Postgres database
+    defaults: "SELECT * FROM sometable"
+
+tasks:
+  - id: query_postgres
+    type: io.kestra.plugin.jdbc.postgresql.Queries
+    url: "{{ secret('POSTGRES_URL') }}"
+    sql: "{{ inputs.query }}"
+    fetchType: STORE

--- a/flows/prometheus-k8s-cpu-spike-alerts.yaml
+++ b/flows/prometheus-k8s-cpu-spike-alerts.yaml
@@ -1,0 +1,166 @@
+id: prometheus-k8s-cpu-spike-alerts
+namespace: company.team
+
+inputs:
+  - id: prometheus_url
+    type: STRING
+    displayName: Prometheus URL
+    description: Base URL of your Prometheus instance
+    defaults: "http://prometheus.monitoring.svc.cluster.local:9090"
+  - id: cpu_threshold_cores
+    type: FLOAT
+    displayName: CPU threshold (cores)
+    description: Alert when a pod's CPU usage exceeds this many cores
+    defaults: 0.8
+  - id: namespace_filter
+    type: STRING
+    displayName: Kubernetes namespace
+    description: Filter pods by namespace (leave empty for all namespaces)
+    defaults: ""
+
+tasks:
+  - id: query_cpu_spikes
+    type: io.kestra.plugin.core.http.Request
+    uri: "{{ inputs.prometheus_url }}/api/v1/query"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('PROMETHEUS_TOKEN') }}"
+    body: |
+      {
+        "query": "sum(rate(container_cpu_usage_seconds_total{container!='',pod!=''}[5m])) by (pod, namespace) > {{ inputs.cpu_threshold_cores }}"
+      }
+
+  - id: parse_spikes
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      prometheus_response.json: "{{ outputs.query_cpu_spikes.body }}"
+    script: |
+      import json
+      from kestra import Kestra
+
+      with open("prometheus_response.json") as f:
+          data = json.load(f)
+
+      namespace_filter = "{{ inputs.namespace_filter }}"
+      threshold = {{ inputs.cpu_threshold_cores }}
+
+      results = data.get("data", {}).get("result", [])
+      spikes = []
+
+      for item in results:
+          metric = item.get("metric", {})
+          pod = metric.get("pod", "unknown")
+          namespace = metric.get("namespace", "unknown")
+          cpu_cores = float(item.get("value", [0, "0"])[1])
+
+          # Apply namespace filter if specified
+          if namespace_filter and namespace != namespace_filter:
+              continue
+
+          spikes.append({
+              "pod": pod,
+              "namespace": namespace,
+              "cpu_cores": round(cpu_cores, 3)
+          })
+
+      # Group by app (prefix before last hyphen-hex suffix)
+      apps = {}
+      for spike in spikes:
+          app_name = "-".join(spike["pod"].split("-")[:-2]) or spike["pod"]
+          if app_name not in apps:
+              apps[app_name] = {"pods": [], "namespace": spike["namespace"]}
+          apps[app_name]["pods"].append(spike)
+
+      Kestra.outputs({
+          "spike_count": len(spikes),
+          "spikes": spikes,
+          "app_groups": apps,
+          "has_spikes": len(spikes) > 0
+      })
+
+  - id: send_alert
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.parse_spikes.vars.has_spikes }}"
+    then:
+      - id: format_and_alert
+        type: io.kestra.plugin.scripts.python.Script
+        inputFiles:
+          spikes.json: "{{ outputs.parse_spikes.vars.spikes | json }}"
+          apps.json: "{{ outputs.parse_spikes.vars.app_groups | json }}"
+        script: |
+          import json
+          from kestra import Kestra
+
+          with open("spikes.json") as f:
+              spikes = json.load(f)
+          with open("apps.json") as f:
+              apps = json.load(f)
+
+          lines = [f":rotating_light: *Kubernetes CPU Spike Alert* — {len(spikes)} pod(s) above threshold\n"]
+          for app, info in apps.items():
+              pods = info["pods"]
+              ns = info["namespace"]
+              if len(pods) == 1:
+                  p = pods[0]
+                  lines.append(f"• `{p['pod']}` ({ns}): *{p['cpu_cores']} cores*")
+              else:
+                  total = sum(p["cpu_cores"] for p in pods)
+                  lines.append(f"• `{app}` ({ns}): *{len(pods)} pods, {round(total,3)} cores total*")
+
+          Kestra.outputs({"slack_message": "\n".join(lines)})
+
+      - id: slack_notification
+        type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        messageText: "{{ outputs.format_and_alert.vars.slack_message }}"
+
+triggers:
+  - id: every_5_minutes
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/5 * * * *"
+    description: Poll Prometheus every 5 minutes
+
+extend:
+  title: Monitor Kubernetes Pod CPU Spikes with Prometheus and Send Grouped Slack Alerts
+  shortDescription: "This blueprint polls Prometheus every 5 minutes for Kubernetes pods exceeding a CPU threshold, groups spikes by application to reduce noise, and fires a structured Slack alert when any pod crosses the limit."
+  description: |
+    This blueprint **polls Prometheus every 5 minutes for Kubernetes pods exceeding a
+    configurable CPU threshold**, groups the spikes by application name to reduce alert
+    noise, and fires a **structured Slack alert** when any pod crosses the limit.
+
+    It demonstrates how to:
+
+    1. Query Prometheus using the **HTTP Request plugin** with the
+       `container_cpu_usage_seconds_total` metric, computing per-pod CPU usage over
+       a 5-minute rolling window via PromQL.
+    2. Parse the Prometheus query response in Python to extract violating pods and their
+       CPU usage, filtering by namespace when specified.
+    3. **Group pods by application name** (stripping the Kubernetes-generated hash suffix)
+       so multi-replica deployments produce a single grouped alert rather than one alert
+       per pod replica.
+    4. Conditionally send a **Slack alert only when spikes are detected**, with a formatted
+       message listing each affected application, namespace, and CPU usage.
+
+    This pattern is ideal for:
+      - **DevOps and SRE teams** that manage Kubernetes clusters and need real-time
+        observability without deploying Alertmanager
+      - **Platform engineers** who want alerting logic co-located with their orchestration
+        pipelines for unified auditability
+      - Teams monitoring **multi-tenant clusters** where namespace-level filtering helps
+        route alerts to the right on-call team
+      - Organizations replacing heavyweight monitoring stacks with lightweight, customizable
+        Kestra-based alerting
+
+    The flow can be extended to add memory and network spike detection in the same run,
+    log all CPU readings to a time-series database, escalate persistent spikes to
+    PagerDuty after repeated alerts, or adjust threshold and schedule dynamically
+    via flow inputs.
+  tags:
+    - DevOps
+    - Infrastructure
+  ee: false
+  demo: false
+  meta_description: |
+    Monitor Kubernetes pod CPU spikes by polling Prometheus every 5 minutes with Kestra.
+    Groups alerts by application name to reduce noise and sends structured Slack notifications
+    when any pod exceeds the configurable CPU threshold.

--- a/flows/prometheus-k8s-cpu-spike-alerts.yaml
+++ b/flows/prometheus-k8s-cpu-spike-alerts.yaml
@@ -157,7 +157,6 @@ extend:
     PagerDuty after repeated alerts, or adjust threshold and schedule dynamically
     via flow inputs.
   tags:
-    - DevOps
     - Infrastructure
   ee: false
   demo: false

--- a/flows/prometheus-k8s-cpu-spike-alerts.yaml
+++ b/flows/prometheus-k8s-cpu-spike-alerts.yaml
@@ -122,6 +122,7 @@ triggers:
 
 extend:
   title: Monitor Kubernetes Pod CPU Spikes with Prometheus and Send Grouped Slack Alerts
+  metaTitle: K8s CPU Spike Alerts with Prometheus
   shortDescription: "This blueprint polls Prometheus every 5 minutes for Kubernetes pods exceeding a CPU threshold, groups spikes by application to reduce noise, and fires a structured Slack alert when any pod crosses the limit."
   description: |
     This blueprint **polls Prometheus every 5 minutes for Kubernetes pods exceeding a
@@ -160,7 +161,4 @@ extend:
     - Infrastructure
   ee: false
   demo: false
-  meta_description: |
-    Monitor Kubernetes pod CPU spikes by polling Prometheus every 5 minutes with Kestra.
-    Groups alerts by application name to reduce noise and sends structured Slack notifications
-    when any pod exceeds the configurable CPU threshold.
+  metaDescription: Monitor Kubernetes pod CPU spikes by polling Prometheus with Kestra. Groups alerts by application and sends Slack notifications when pods exceed the CPU threshold.

--- a/flows/rss-to-mastodon-feed.yaml
+++ b/flows/rss-to-mastodon-feed.yaml
@@ -19,11 +19,7 @@ extend:
     - **Open-source project maintainers** syncing blog or release-feed updates to their
       Mastodon presence
   tags:
-    - RSS
-    - Mastodon
-    - Social Media
-    - Scheduling
-    - Feeds
+    - Business
   ee: false
   demo: false
   metaDescription: Poll a Tiny Tiny RSS public feed every 10 minutes and post new items to Mastodon, using Kestra KV store to track the last-posted item and prevent duplicates.

--- a/flows/rss-to-mastodon-feed.yaml
+++ b/flows/rss-to-mastodon-feed.yaml
@@ -1,0 +1,106 @@
+extend:
+  title: Post New RSS Feed Items to Mastodon
+  shortDescription: Poll a Tiny Tiny RSS public feed every 10 minutes and toot new items to Mastodon
+  description: |
+    **Monitors a tt-rss public feed on a schedule and posts each new item as a Mastodon status,
+    using KV store to avoid duplicate toots.**
+
+    1. Schedule trigger runs every 10 minutes.
+    2. HTTP Request fetches the RSS feed XML from the configured tt-rss public URL.
+    3. Python Script parses the feed XML, extracts item IDs, titles, and links, then filters
+       to only items newer than the last-posted ID stored in KV.
+    4. ForEach posts each new item to the Mastodon Statuses API as a toot with title and link.
+    5. KV Set persists the latest item ID to prevent duplicate toots on the next run.
+
+    Ideal for:
+    - **Content curators** aggregating feeds in tt-rss who want automatic cross-posting to
+      Mastodon without manual effort
+    - **Open-source project maintainers** syncing blog or release-feed updates to their
+      Mastodon presence
+  tags:
+    - RSS
+    - Mastodon
+    - Social Media
+    - Scheduling
+    - Feeds
+  ee: false
+  demo: false
+  meta_description: Poll a Tiny Tiny RSS public feed every 10 minutes and post new items to Mastodon, using Kestra KV store to track the last-posted item and prevent duplicates.
+
+id: rss-to-mastodon-feed
+namespace: company.team
+
+inputs:
+  - id: rss_feed_url
+    type: STRING
+    displayName: tt-rss Public Feed URL
+    description: Full URL of the Tiny Tiny RSS public published feed
+  - id: mastodon_instance
+    type: STRING
+    displayName: Mastodon Instance Domain
+    description: Domain of your Mastodon instance, e.g. mastodon.social
+
+tasks:
+  - id: fetch_rss_feed
+    type: io.kestra.plugin.core.http.Request
+    uri: "{{ inputs.rss_feed_url }}"
+    method: GET
+
+  - id: get_last_posted_id
+    type: io.kestra.plugin.core.kv.Get
+    key: rss_mastodon_last_id
+    errorOnMissing: false
+
+  - id: parse_new_items
+    type: io.kestra.plugin.scripts.python.Script
+    beforeCommands:
+      - pip install defusedxml -q
+    script: |
+      import json
+      import defusedxml.ElementTree as ET
+      from kestra import Kestra
+
+      last_id = "{{ outputs.get_last_posted_id.value | default('') }}"
+      xml_body = open("/tmp/feed.xml", "w")
+      xml_body.write("""{{ outputs.fetch_rss_feed.body }}""")
+      xml_body.close()
+
+      root = ET.parse("/tmp/feed.xml").getroot()
+      items = []
+      for entry in root.findall(".//item"):
+          guid = (entry.findtext("guid") or "").strip().split("/")[-1]
+          if guid == last_id:
+              break
+          items.append({
+              "id": guid,
+              "title": (entry.findtext("title") or "").strip(),
+              "link": (entry.findtext("link") or "").strip()
+          })
+
+      latest_id = items[0]["id"] if items else last_id
+      Kestra.outputs({"new_items": json.dumps(items), "latest_id": latest_id})
+
+  - id: post_new_items
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ outputs.parse_new_items.vars.new_items }}"
+    concurrencyLimit: 1
+    tasks:
+      - id: toot_item
+        type: io.kestra.plugin.core.http.Request
+        uri: "https://{{ inputs.mastodon_instance }}/api/v1/statuses"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ secret('MASTODON_ACCESS_TOKEN') }}"
+          Content-Type: "application/json"
+        body: |
+          {"status": "{{ taskrun.value | jq('.title') | first }} {{ taskrun.value | jq('.link') | first }}"}
+
+  - id: update_last_id
+    type: io.kestra.plugin.core.kv.Set
+    key: rss_mastodon_last_id
+    value: "{{ outputs.parse_new_items.vars.latest_id }}"
+
+triggers:
+  - id: every_ten_minutes
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/10 * * * *"

--- a/flows/rss-to-mastodon-feed.yaml
+++ b/flows/rss-to-mastodon-feed.yaml
@@ -1,5 +1,6 @@
 extend:
   title: Post New RSS Feed Items to Mastodon
+  metaTitle: Post RSS Feed Items to Mastodon
   shortDescription: Poll a Tiny Tiny RSS public feed every 10 minutes and toot new items to Mastodon
   description: |
     **Monitors a tt-rss public feed on a schedule and posts each new item as a Mastodon status,
@@ -25,7 +26,7 @@ extend:
     - Feeds
   ee: false
   demo: false
-  meta_description: Poll a Tiny Tiny RSS public feed every 10 minutes and post new items to Mastodon, using Kestra KV store to track the last-posted item and prevent duplicates.
+  metaDescription: Poll a Tiny Tiny RSS public feed every 10 minutes and post new items to Mastodon, using Kestra KV store to track the last-posted item and prevent duplicates.
 
 id: rss-to-mastodon-feed
 namespace: company.team

--- a/flows/ssl-certificate-expiry-monitor.yaml
+++ b/flows/ssl-certificate-expiry-monitor.yaml
@@ -1,0 +1,163 @@
+id: ssl-certificate-expiry-monitor
+namespace: company.team
+
+inputs:
+  - id: domains
+    type: ARRAY
+    itemType: STRING
+    displayName: Domains to monitor
+    description: List of domains to check SSL certificate expiry for
+    defaults:
+      - "google.com"
+      - "github.com"
+      - "kestra.io"
+  - id: warning_days
+    type: INT
+    displayName: Warning threshold (days)
+    description: Alert when a certificate expires within this many days
+    defaults: 30
+
+tasks:
+  - id: check_certificates
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ inputs.domains }}"
+    concurrencyLimit: 5
+    tasks:
+      - id: fetch_ssl_info
+        type: io.kestra.plugin.core.http.Request
+        uri: "https://ssl-checker.io/api/v1/check/{{ taskrun.value }}"
+        method: GET
+
+      - id: get_expiry_state
+        type: io.kestra.plugin.core.kv.Get
+        key: "ssl_alerted_{{ taskrun.value | replace('.', '_') }}"
+        errorOnMissing: false
+
+      - id: evaluate_cert
+        type: io.kestra.plugin.scripts.python.Script
+        inputFiles:
+          ssl_data.json: "{{ outputs.fetch_ssl_info[taskrun.value].body }}"
+        script: |
+          import json
+          from datetime import datetime, timezone
+          from kestra import Kestra
+
+          with open("ssl_data.json") as f:
+              data = json.load(f)
+
+          domain = "{{ taskrun.value }}"
+          warning_days = {{ inputs.warning_days }}
+
+          # Parse expiry date from SSL checker response
+          expiry_str = data.get("cert_exp_date", "")
+          is_valid = data.get("cert_valid", False)
+
+          days_left = None
+          is_expiring = False
+
+          if expiry_str:
+              try:
+                  expiry_dt = datetime.strptime(expiry_str, "%Y-%m-%dT%H:%M:%S")
+                  now = datetime.utcnow()
+                  days_left = (expiry_dt - now).days
+                  is_expiring = days_left <= warning_days
+              except Exception as e:
+                  print(f"Error parsing date: {e}")
+
+          Kestra.outputs({
+              "domain": domain,
+              "days_left": days_left,
+              "expiry_date": expiry_str,
+              "is_valid": is_valid,
+              "is_expiring": is_expiring or not is_valid,
+              "alert_message": (
+                  f"INVALID certificate for {domain}"
+                  if not is_valid
+                  else f"Certificate for {domain} expires in {days_left} days ({expiry_str})"
+              )
+          })
+
+      - id: send_alert
+        type: io.kestra.plugin.core.flow.If
+        condition: "{{ outputs.evaluate_cert[taskrun.value].vars.is_expiring and outputs.get_expiry_state[taskrun.value].value != 'alerted' }}"
+        then:
+          - id: slack_alert
+            type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+            url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+            messageText: |
+              :warning: *SSL Certificate Alert*
+              Domain: `{{ taskrun.value }}`
+              {{ outputs.evaluate_cert[taskrun.value].vars.alert_message }}
+              Action required: Renew the certificate immediately.
+
+          - id: email_alert
+            type: io.kestra.plugin.email.MailSend
+            from: "{{ secret('ALERT_EMAIL_FROM') }}"
+            to: "{{ secret('ALERT_EMAIL_TO') }}"
+            subject: "[SSL ALERT] Certificate expiring: {{ taskrun.value }}"
+            htmlTextContent: |
+              <h2 style="color:orange;">SSL Certificate Expiry Warning</h2>
+              <p><strong>Domain:</strong> {{ taskrun.value }}</p>
+              <p>{{ outputs.evaluate_cert[taskrun.value].vars.alert_message }}</p>
+              <p>Please renew the certificate immediately to avoid service disruption.</p>
+            host: "{{ secret('SMTP_HOST') }}"
+            username: "{{ secret('SMTP_USERNAME') }}"
+            password: "{{ secret('SMTP_PASSWORD') }}"
+            port: 465
+
+          - id: mark_alerted
+            type: io.kestra.plugin.core.kv.Set
+            key: "ssl_alerted_{{ taskrun.value | replace('.', '_') }}"
+            value: "alerted"
+            kvType: STRING
+
+triggers:
+  - id: weekly_check
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 9 * * 1"
+    description: Run every Monday at 09:00 UTC
+
+extend:
+  title: Monitor SSL Certificate Expiry and Alert via Slack and Email Before They Expire
+  shortDescription: "This blueprint monitors SSL certificate expiry for a list of domains on a weekly schedule, checks the days remaining until expiration, and fires Slack and email alerts only when a certificate crosses the warning threshold — avoiding duplicate notifications via KV state tracking."
+  description: |
+    This blueprint **monitors SSL certificate expiry for a configurable list of domains**
+    on a weekly schedule, checks the days remaining until expiration, and fires **Slack
+    and email alerts only when a certificate crosses the warning threshold** — avoiding
+    duplicate notifications via KV state tracking.
+
+    It demonstrates how to:
+
+    1. Check SSL certificate details for each domain in parallel using the public
+       **ssl-checker.io API**, retrieving expiry date and validity status.
+    2. Parse the expiry date in Python and compute **days remaining** until certificate
+       expiration, flagging both soon-to-expire and already-invalid certificates.
+    3. Use the **KV store** to track which domains have already been alerted, preventing
+       repeat notifications on every run until the certificate is renewed.
+    4. Fire **Slack and email alerts** with actionable context when a certificate falls
+       below the configurable warning threshold (default: 30 days).
+    5. Schedule the check to run every **Monday at 09:00 UTC**, ensuring weekly coverage
+       with minimal operational overhead.
+
+    This pattern is ideal for:
+      - **DevOps and security teams** responsible for certificate lifecycle management
+        across multiple domains and services
+      - **SaaS companies** that need to proactively catch certificate expirations before
+        they cause browser warnings or service outages
+      - **Agencies and freelancers** managing SSL for multiple client websites
+      - Teams replacing paid monitoring tools like SSL Shopper or Pingdom with a
+        self-hosted, fully-controlled pipeline
+
+    The flow can be extended to log all certificate statuses to a Postgres table,
+    escalate critical (≤7 days) certificates to PagerDuty, reset the KV alert state
+    automatically after a renewal is detected, or check internal certificates via
+    custom SSL inspection endpoints.
+  tags:
+    - DevOps
+    - SecOps
+  ee: false
+  demo: false
+  meta_description: |
+    Monitor SSL certificate expiry across multiple domains with Kestra. Checks days
+    remaining via ssl-checker.io, tracks alert state in KV store to prevent duplicates,
+    and fires Slack and email notifications when certificates approach expiration.

--- a/flows/ssl-certificate-expiry-monitor.yaml
+++ b/flows/ssl-certificate-expiry-monitor.yaml
@@ -119,6 +119,7 @@ triggers:
 
 extend:
   title: Monitor SSL Certificate Expiry and Alert via Slack and Email Before They Expire
+  metaTitle: SSL Certificate Expiry Monitor
   shortDescription: "This blueprint monitors SSL certificate expiry for a list of domains on a weekly schedule, checks the days remaining until expiration, and fires Slack and email alerts only when a certificate crosses the warning threshold — avoiding duplicate notifications via KV state tracking."
   description: |
     This blueprint **monitors SSL certificate expiry for a configurable list of domains**
@@ -157,7 +158,4 @@ extend:
     - SecOps
   ee: false
   demo: false
-  meta_description: |
-    Monitor SSL certificate expiry across multiple domains with Kestra. Checks days
-    remaining via ssl-checker.io, tracks alert state in KV store to prevent duplicates,
-    and fires Slack and email notifications when certificates approach expiration.
+  metaDescription: Monitor SSL certificate expiry across multiple domains with Kestra. Checks days remaining, tracks alert state in KV store, and fires Slack and email notifications.

--- a/flows/ssl-certificate-expiry-monitor.yaml
+++ b/flows/ssl-certificate-expiry-monitor.yaml
@@ -154,8 +154,7 @@ extend:
     automatically after a renewal is detected, or check internal certificates via
     custom SSL inspection endpoints.
   tags:
-    - DevOps
-    - SecOps
+    - Infrastructure
   ee: false
   demo: false
   metaDescription: Monitor SSL certificate expiry across multiple domains with Kestra. Checks days remaining, tracks alert state in KV store, and fires Slack and email notifications.

--- a/flows/stripe-to-crm-sync.yaml
+++ b/flows/stripe-to-crm-sync.yaml
@@ -150,6 +150,7 @@ triggers:
 
 extend:
   title: Sync Stripe Payments and Customer Data to a PostgreSQL CRM Database Daily
+  metaTitle: Sync Stripe Payments to PostgreSQL CRM
   shortDescription: "This blueprint fetches Stripe charges and customer records, merges them into enriched payment records, and upserts them to a PostgreSQL CRM table daily — building a queryable payment history with deduplication."
   description: |
     This blueprint **fetches Stripe charges and customer records, merges them into enriched
@@ -186,7 +187,4 @@ extend:
     - Business
   ee: false
   demo: false
-  meta_description: |
-    Sync Stripe payments and customer data to PostgreSQL daily with Kestra. Merges charge
-    and customer records, upserts to a CRM table with deduplication, and tracks sync
-    state via KV store — no manual exports required.
+  metaDescription: Sync Stripe payments and customer data to PostgreSQL daily with Kestra. Merges charge and customer records, upserts to a CRM table with deduplication.

--- a/flows/stripe-to-crm-sync.yaml
+++ b/flows/stripe-to-crm-sync.yaml
@@ -1,0 +1,192 @@
+id: stripe-to-crm-sync
+namespace: company.team
+
+inputs:
+  - id: lookback_hours
+    type: INT
+    displayName: Lookback window (hours)
+    description: How many hours back to fetch Stripe payments (default 24 for daily sync)
+    defaults: 24
+
+tasks:
+  - id: get_last_sync_time
+    type: io.kestra.plugin.core.kv.Get
+    key: stripe_crm_last_sync_ts
+    errorOnMissing: false
+
+  - id: fetch_stripe_payments
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://api.stripe.com/v1/charges?limit=100&created[gte]={{ (now() | dateAdd(-inputs.lookback_hours, 'HOURS') | date('X')) }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('STRIPE_SECRET_KEY') }}"
+
+  - id: fetch_stripe_customers
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://api.stripe.com/v1/customers?limit=100"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('STRIPE_SECRET_KEY') }}"
+
+  - id: merge_and_enrich
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      payments.json: "{{ outputs.fetch_stripe_payments.body }}"
+      customers.json: "{{ outputs.fetch_stripe_customers.body }}"
+    script: |
+      import json
+      from kestra import Kestra
+
+      with open("payments.json") as f:
+          payments_data = json.load(f)
+      with open("customers.json") as f:
+          customers_data = json.load(f)
+
+      # Build customer lookup
+      customer_map = {
+          c["id"]: c
+          for c in customers_data.get("data", [])
+      }
+
+      enriched = []
+      for payment in payments_data.get("data", []):
+          customer_id = payment.get("customer")
+          customer = customer_map.get(customer_id, {}) if customer_id else {}
+
+          enriched.append({
+              "payment_id": payment.get("id"),
+              "customer_id": customer_id,
+              "customer_email": customer.get("email") or payment.get("billing_details", {}).get("email"),
+              "customer_name": customer.get("name") or payment.get("billing_details", {}).get("name"),
+              "amount_cents": payment.get("amount", 0),
+              "amount": payment.get("amount", 0) / 100,
+              "currency": payment.get("currency", "usd").upper(),
+              "status": payment.get("status"),
+              "description": payment.get("description") or "",
+              "created_ts": payment.get("created", 0),
+              "metadata": json.dumps(payment.get("metadata", {}))
+          })
+
+      Kestra.outputs({"records": enriched, "count": len(enriched)})
+
+  - id: upsert_to_postgres
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      records.json: "{{ outputs.merge_and_enrich.vars.records | json }}"
+    dependencies:
+      - psycopg2-binary
+    script: |
+      import json
+      import psycopg2
+      import os
+
+      with open("records.json") as f:
+          records = json.load(f)
+
+      conn = psycopg2.connect(
+          host=os.getenv("POSTGRES_HOST"),
+          dbname=os.getenv("POSTGRES_DB"),
+          user=os.getenv("POSTGRES_USER_VAL"),
+          password=os.getenv("POSTGRES_PASS_VAL"),
+          port=5432
+      )
+      cur = conn.cursor()
+
+      cur.execute("""
+          CREATE TABLE IF NOT EXISTS crm_payments (
+              payment_id TEXT PRIMARY KEY,
+              customer_id TEXT,
+              customer_email TEXT,
+              customer_name TEXT,
+              amount NUMERIC,
+              currency TEXT,
+              status TEXT,
+              description TEXT,
+              created_ts BIGINT,
+              metadata JSONB,
+              synced_at TIMESTAMP DEFAULT NOW()
+          )
+      """)
+
+      for r in records:
+          cur.execute("""
+              INSERT INTO crm_payments
+                  (payment_id, customer_id, customer_email, customer_name, amount, currency,
+                   status, description, created_ts, metadata)
+              VALUES
+                  (%(payment_id)s, %(customer_id)s, %(customer_email)s, %(customer_name)s,
+                   %(amount)s, %(currency)s, %(status)s, %(description)s, %(created_ts)s, %(metadata)s)
+              ON CONFLICT (payment_id) DO UPDATE SET
+                  status = EXCLUDED.status,
+                  synced_at = NOW()
+          """, {**r, 'metadata': r['metadata']})
+
+      conn.commit()
+      cur.close()
+      conn.close()
+      print(f"Synced {len(records)} records to crm_payments table")
+    env:
+      POSTGRES_HOST: "{{ secret('POSTGRES_HOST') }}"
+      POSTGRES_DB: "{{ secret('POSTGRES_DB') }}"
+      POSTGRES_USER_VAL: "{{ secret('POSTGRES_USER') }}"
+      POSTGRES_PASS_VAL: "{{ secret('POSTGRES_PASSWORD') }}"
+
+  - id: update_sync_timestamp
+    type: io.kestra.plugin.core.kv.Set
+    key: stripe_crm_last_sync_ts
+    value: "{{ now() | date('yyyy-MM-dd HH:mm:ss') }}"
+    kvType: STRING
+
+  - id: notify_slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    messageText: ":white_check_mark: Stripe → CRM sync complete: *{{ outputs.merge_and_enrich.vars.count }}* payments synchronized at {{ now() | date('yyyy-MM-dd HH:mm') }} UTC"
+
+triggers:
+  - id: daily_sync
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 6 * * *"
+    description: Sync Stripe payments to CRM database every day at 06:00 UTC
+
+extend:
+  title: Sync Stripe Payments and Customer Data to a PostgreSQL CRM Database Daily
+  shortDescription: "This blueprint fetches Stripe charges and customer records, merges them into enriched payment records, and upserts them to a PostgreSQL CRM table daily — building a queryable payment history with deduplication."
+  description: |
+    This blueprint **fetches Stripe charges and customer records, merges them into enriched
+    payment records, and upserts them to a PostgreSQL CRM table daily** — building a
+    queryable, deduplicated payment history that serves as the foundation for sales
+    reporting, customer analytics, and CRM automation.
+
+    It demonstrates how to:
+
+    1. Fetch **Stripe charges** for a configurable lookback window using the Stripe REST
+       API, tracking incremental sync progress via the **KV store** to avoid processing
+       duplicates.
+    2. Fetch **Stripe customer profiles** and **merge them with payment data** in Python,
+       enriching each transaction with customer name and email for CRM-ready records.
+    3. **Upsert enriched records to PostgreSQL** using `INSERT ... ON CONFLICT DO UPDATE`
+       to create an ever-growing, deduplicated payment history in a CRM table.
+    4. Track the last sync timestamp in **KV store** and post a Slack confirmation on
+       completion with the record count.
+
+    This pattern is ideal for:
+      - **SaaS companies** building a customer revenue history in their data warehouse
+        without a dedicated ETL tool
+      - **Sales and finance teams** who need Stripe data queryable alongside product
+        and CRM data in a single Postgres database
+      - **Analysts** building MRR, churn, and customer LTV reports from raw Stripe data
+      - Teams replacing manual Stripe CSV exports with an automated, scheduled pipeline
+
+    The flow can be extended to enrich records with product SKU data from the Stripe
+    line items, push new customers to a CRM like HubSpot or Salesforce via their APIs,
+    trigger workflows when a customer reaches a revenue milestone, or add refund and
+    dispute tracking.
+  tags:
+    - Data
+    - Business
+  ee: false
+  demo: false
+  meta_description: |
+    Sync Stripe payments and customer data to PostgreSQL daily with Kestra. Merges charge
+    and customer records, upserts to a CRM table with deduplication, and tracks sync
+    state via KV store — no manual exports required.

--- a/flows/webhook-xml-response.yaml
+++ b/flows/webhook-xml-response.yaml
@@ -1,5 +1,6 @@
 extend:
   title: Return XML from a Webhook Request
+  metaTitle: Return XML from a Webhook Request
   shortDescription: Accept an HTTP POST webhook and respond with XML-formatted data
   description: |
     **Receives an HTTP POST request on a webhook endpoint, builds a structured data object, and
@@ -22,7 +23,7 @@ extend:
     - Integration
   ee: false
   demo: true
-  meta_description: Accept HTTP POST webhook requests and respond with structured XML data, demonstrating JSON-to-XML conversion and custom response headers in Kestra.
+  metaDescription: Accept HTTP POST webhook requests and respond with structured XML data, demonstrating JSON-to-XML conversion and custom response headers in Kestra.
 
 id: webhook-xml-response
 namespace: company.team

--- a/flows/webhook-xml-response.yaml
+++ b/flows/webhook-xml-response.yaml
@@ -17,10 +17,7 @@ extend:
       rather than JSON
     - **Webhook testing scenarios** where response format and content-type validation are needed
   tags:
-    - Webhook
-    - XML
-    - API
-    - Integration
+    - Core
   ee: false
   demo: true
   metaDescription: Accept HTTP POST webhook requests and respond with structured XML data, demonstrating JSON-to-XML conversion and custom response headers in Kestra.

--- a/flows/webhook-xml-response.yaml
+++ b/flows/webhook-xml-response.yaml
@@ -1,0 +1,53 @@
+extend:
+  title: Return XML from a Webhook Request
+  shortDescription: Accept an HTTP POST webhook and respond with XML-formatted data
+  description: |
+    **Receives an HTTP POST request on a webhook endpoint, builds a structured data object, and
+    returns it as XML with the correct content-type header.**
+
+    1. Webhook trigger listens for POST requests and waits for the flow to complete before
+       responding, with `responseContentType` set to `application/xml`.
+    2. Python Script creates a sample data object with a string and a number field.
+    3. Python Script serialises the object to an XML document string and outputs it.
+    4. The webhook returns the XML output to the caller via `returnOutputs: true`.
+
+    Ideal for:
+    - **API integration developers** building adapters for legacy systems that consume XML
+      rather than JSON
+    - **Webhook testing scenarios** where response format and content-type validation are needed
+  tags:
+    - Webhook
+    - XML
+    - API
+    - Integration
+  ee: false
+  demo: true
+  meta_description: Accept HTTP POST webhook requests and respond with structured XML data, demonstrating JSON-to-XML conversion and custom response headers in Kestra.
+
+id: webhook-xml-response
+namespace: company.team
+
+tasks:
+  - id: build_xml
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import xml.etree.ElementTree as ET
+      from kestra import Kestra
+
+      data = {"number": "1", "string": "my text"}
+      root = ET.Element("root")
+      for key, value in data.items():
+          child = ET.SubElement(root, key)
+          child.text = value
+      xml_string = ET.tostring(root, encoding="unicode")
+      Kestra.outputs({"xml": xml_string})
+
+triggers:
+  - id: webhook_trigger
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "{{ secret('WEBHOOK_SECRET_KEY') }}"
+    # Kestra webhook only supports application/json or text/plain for responseContentType.
+    # The XML string is returned as a JSON field; callers parse outputs.build_xml.vars.xml.
+    responseContentType: "application/json"
+    returnOutputs: true
+    wait: true

--- a/flows/website-monitoring-with-alerts.yaml
+++ b/flows/website-monitoring-with-alerts.yaml
@@ -1,0 +1,130 @@
+id: website-monitoring-with-alerts
+namespace: company.team
+
+inputs:
+  - id: websites
+    type: ARRAY
+    itemType: STRING
+    displayName: Websites to monitor
+    description: List of URLs to check for availability
+    defaults:
+      - "https://example.com"
+      - "https://another-site.com"
+
+tasks:
+  - id: check_sites
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ inputs.websites }}"
+    concurrencyLimit: 5
+    tasks:
+      - id: http_check
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ taskrun.value }}"
+        method: GET
+        options:
+          allowFailed: true
+          connectTimeout: PT10S
+          readTimeout: PT15S
+
+      - id: get_previous_status
+        type: io.kestra.plugin.core.kv.Get
+        key: "site_status_{{ taskrun.value | replace('://', '_') | replace('/', '_') | replace('.', '_') }}"
+        errorOnMissing: false
+
+      - id: is_down
+        type: io.kestra.plugin.core.flow.If
+        condition: "{{ outputs.http_check[taskrun.value].code >= 400 or outputs.http_check[taskrun.value].code == null }}"
+        then:
+          - id: save_down_status
+            type: io.kestra.plugin.core.kv.Set
+            key: "site_status_{{ taskrun.value | replace('://', '_') | replace('/', '_') | replace('.', '_') }}"
+            value: "DOWN"
+            kvType: STRING
+
+          - id: notify_down_slack
+            type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+            url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+            messageText: |
+              :red_circle: *Website Down Alert*
+              URL: {{ taskrun.value }}
+              Status: {{ outputs.http_check[taskrun.value].code | default('unreachable') }}
+              Time: {{ now() | date('yyyy-MM-dd HH:mm:ss') }} UTC
+
+          - id: notify_down_email
+            type: io.kestra.plugin.email.MailSend
+            from: "{{ secret('ALERT_EMAIL_FROM') }}"
+            to: "{{ secret('ALERT_EMAIL_TO') }}"
+            subject: "[ALERT] Website Down: {{ taskrun.value }}"
+            htmlTextContent: |
+              <h2 style="color:red;">Website Down Alert</h2>
+              <p><strong>URL:</strong> {{ taskrun.value }}</p>
+              <p><strong>HTTP Status:</strong> {{ outputs.http_check[taskrun.value].code | default('unreachable') }}</p>
+              <p><strong>Time:</strong> {{ now() | date('yyyy-MM-dd HH:mm:ss') }} UTC</p>
+            host: "{{ secret('SMTP_HOST') }}"
+            username: "{{ secret('SMTP_USERNAME') }}"
+            password: "{{ secret('SMTP_PASSWORD') }}"
+            port: 465
+        else:
+          - id: save_up_status
+            type: io.kestra.plugin.core.kv.Set
+            key: "site_status_{{ taskrun.value | replace('://', '_') | replace('/', '_') | replace('.', '_') }}"
+            value: "UP"
+            kvType: STRING
+
+          - id: notify_recovery
+            type: io.kestra.plugin.core.flow.If
+            condition: "{{ outputs.get_previous_status[taskrun.value].value == 'DOWN' }}"
+            then:
+              - id: notify_recovery_slack
+                type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+                url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+                messageText: |
+                  :large_green_circle: *Website Recovered*
+                  URL: {{ taskrun.value }}
+                  Status: {{ outputs.http_check[taskrun.value].code }}
+                  Time: {{ now() | date('yyyy-MM-dd HH:mm:ss') }} UTC
+
+triggers:
+  - id: every_5_minutes
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/5 * * * *"
+    description: Poll all configured websites every 5 minutes
+
+extend:
+  title: Monitor Multiple Websites and Send Instant Downtime Alerts via Slack and Email
+  shortDescription: "This blueprint continuously monitors a configurable list of websites every 5 minutes, detects outages using HTTP health checks, and delivers instant downtime and recovery alerts via Slack and email."
+  description: |
+    This blueprint **continuously monitors a configurable list of websites every 5 minutes**,
+    detects outages using HTTP health checks, and delivers **instant downtime and recovery
+    alerts** via Slack and email — with persistent state tracking to avoid duplicate notifications.
+
+    It demonstrates how to:
+
+    1. Iterate in parallel over a list of website URLs provided as a flow input, executing
+       concurrent health checks with configurable connection and read timeouts.
+    2. Track the **last known status** of each website across executions using the **KV store**,
+       enabling the flow to distinguish a new outage from an already-known one.
+    3. Detect HTTP failures (status codes ≥ 400 or unreachable hosts) and immediately fire
+       **Slack and email alerts** with the URL, status code, and timestamp.
+    4. Detect **site recovery** (transition from DOWN to UP) and send a dedicated recovery
+       notification to close the incident loop.
+
+    This pattern is ideal for:
+      - **Startups and SaaS teams** that want lightweight uptime monitoring without paying for
+        external tools like Pingdom or UptimeRobot
+      - **DevOps and platform teams** that already use Kestra and want monitoring co-located
+        with their automation pipelines
+      - **Freelancers and agencies** managing multiple client sites from a single workflow
+      - Teams that need **customizable alerting logic** — e.g., alert only after N consecutive failures
+
+    The flow can be extended to add a Postgres log table for historical downtime records,
+    escalate to PagerDuty after repeated failures, or check SSL certificate expiry in the same pass.
+  tags:
+    - DevOps
+    - Core
+  ee: false
+  demo: false
+  meta_description: |
+    Monitor multiple websites every 5 minutes with Kestra. Detects HTTP outages and site recoveries
+    using persistent KV state tracking, then fires instant alerts via Slack and email — no external
+    monitoring tools required.

--- a/flows/website-monitoring-with-alerts.yaml
+++ b/flows/website-monitoring-with-alerts.yaml
@@ -121,7 +121,7 @@ extend:
     The flow can be extended to add a Postgres log table for historical downtime records,
     escalate to PagerDuty after repeated failures, or check SSL certificate expiry in the same pass.
   tags:
-    - DevOps
+    - Infrastructure
     - Core
   ee: false
   demo: false

--- a/flows/website-monitoring-with-alerts.yaml
+++ b/flows/website-monitoring-with-alerts.yaml
@@ -92,6 +92,7 @@ triggers:
 
 extend:
   title: Monitor Multiple Websites and Send Instant Downtime Alerts via Slack and Email
+  metaTitle: Website Uptime Monitoring with Alerts
   shortDescription: "This blueprint continuously monitors a configurable list of websites every 5 minutes, detects outages using HTTP health checks, and delivers instant downtime and recovery alerts via Slack and email."
   description: |
     This blueprint **continuously monitors a configurable list of websites every 5 minutes**,
@@ -124,7 +125,4 @@ extend:
     - Core
   ee: false
   demo: false
-  meta_description: |
-    Monitor multiple websites every 5 minutes with Kestra. Detects HTTP outages and site recoveries
-    using persistent KV state tracking, then fires instant alerts via Slack and email — no external
-    monitoring tools required.
+  metaDescription: Monitor multiple websites every 5 minutes with Kestra. Detects HTTP outages and site recoveries using KV state tracking, and fires alerts via Slack and email.


### PR DESCRIPTION
## Summary

- Adds 24 new blueprints covering AI-powered workflows, data engineering pipelines, DevOps/monitoring, and third-party integrations
- All blueprints include full `extend` metadata (title, description, tags, shortDescription)

## New Blueprints

**AI Workflows**
- `ai-blog-post-generator` — Generate brand-voice blog posts with GPT-4o and publish to WordPress
- `ai-document-data-extraction` — Extract structured data from documents using AI
- `ai-github-pr-review` — Automated PR code review with LLMs
- `ai-inventory-forecasting` — AI-driven inventory demand forecasting
- `ai-model-router` — Route prompts to different LLM models based on task type
- `ai-rag-ingest-and-query` — RAG pipeline: ingest documents and query with LLMs
- `ai-rss-news-digest` — Summarize RSS feeds into daily AI-generated digests
- `ai-semantic-cache-redis` — Semantic caching layer for LLM responses using Redis
- `ai-slack-chatbot-with-memory` — Slack chatbot with persistent conversation memory
- `ai-stock-analysis-alerts` — AI-powered stock analysis with alerts
- `ai-text-to-sql-openai` — Natural language to SQL query generation

**Data Engineering / ETL**
- `csv-url-to-postgres` — Fetch a CSV from a URL and load it into PostgreSQL
- `hackernews-etl-to-postgres` — ETL pipeline from Hacker News API to PostgreSQL
- `postgres-query-executor` — Execute a parameterised SQL query on Postgres and store results
- `stripe-to-crm-sync` — Sync Stripe payment data to a CRM

**DevOps / Monitoring**
- `git-backup-flows-to-github` — Backup Kestra flows to a GitHub repository
- `incident-response-jira-slack` — Automated incident response with Jira and Slack
- `prometheus-k8s-cpu-spike-alerts` — Alert on Kubernetes CPU spikes via Prometheus
- `ssl-certificate-expiry-monitor` — Monitor SSL certificate expiry and alert on renewal
- `website-monitoring-with-alerts` — Monitor website uptime and send alerts

**Integrations**
- `github-star-slack-notification` — Notify Slack when a GitHub repo is starred or unstarred
- `google-sheets-to-mailchimp-sync` — Sync Google Sheets leads to a Mailchimp subscriber list
- `rss-to-mastodon-feed` — Post new RSS feed items to Mastodon
- `webhook-xml-response` — Accept an HTTP POST webhook and respond with XML-formatted data

## Test plan
- [ ] Review YAML syntax for each blueprint
- [ ] Verify `extend` metadata is complete and accurate
- [ ] Check plugin references are valid (`io.kestra.plugin.*`)