### PR TITLE
fix: enforce blueprint tag validation on all files

### DIFF
--- a/.github/workflows/validate-blueprint-tags.yml
+++ b/.github/workflows/validate-blueprint-tags.yml
@@ -65,11 +65,14 @@ jobs:
                       if tag not in allowed_tags:
                           invalid_tags.append(tag)
 
-                  # Check for too many tags
+                  # Check for issues (report both if both exist)
+                  issues = []
+                  if invalid_tags:
+                      issues.append(f'INVALID:{invalid_tags}')
                   if len(tags) > 3:
-                      print(f'OVER_LIMIT:{len(tags)}:{tags}')
-                  elif invalid_tags:
-                      print(f'INVALID:{invalid_tags}')
+                      issues.append(f'OVER_LIMIT:{len(tags)}:{tags}')
+                  if issues:
+                      print('|'.join(issues))
                   else:
                       print('VALID')
               else:
@@ -79,21 +82,23 @@ jobs:
           ")
 
             # Process the result
-            if [[ $RESULT == OVER_LIMIT:* ]]; then
-              OVER_LIMIT_FILES+=("$file")
-              echo "  ❌ Too many tags: $RESULT"
-            elif [[ $RESULT == INVALID:* ]]; then
+            if [[ $RESULT == *INVALID:* ]]; then
               INVALID_FILES+=("$file")
               echo "  ❌ Invalid tags: $RESULT"
-            elif [[ $RESULT == VALID ]]; then
+            fi
+            if [[ $RESULT == *OVER_LIMIT:* ]]; then
+              OVER_LIMIT_FILES+=("$file")
+              echo "  ❌ Too many tags: $RESULT"
+            fi
+            if [[ $RESULT == VALID ]]; then
               echo "  ✅ Valid"
             elif [[ $RESULT == NO_TAGS ]]; then
               echo "  ⚠️  No tags found"
-            else
+            elif [[ $RESULT != *INVALID:* && $RESULT != *OVER_LIMIT:* ]]; then
               echo "  ❓ Unexpected result: $RESULT"
             fi
 
-          done < <(find flows -name "*.yaml" -o -name "*.yml" -print0)
+          done < <(find flows \( -name "*.yaml" -o -name "*.yml" \) -print0)
 
           echo
 

--- a/.github/workflows/validate-blueprint-tags.yml
+++ b/.github/workflows/validate-blueprint-tags.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'flows/*.yaml'
-      - 'flows/*.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Fixed `find` command missing parentheses around the OR condition — `-print0` only applied to `*.yml` files, so **only 11 out of 260** blueprint files were actually validated
- Fixed validation logic to report both invalid tags and over-limit issues simultaneously
