### PR TITLE
fix: update titles to be easier to read

### DIFF
--- a/apps/display-outputs-from-past-execution.yaml
+++ b/apps/display-outputs-from-past-execution.yaml
@@ -21,7 +21,7 @@ description: |
   It's useful to share the results of a flow with external stakeholders.
 extend:
   shortDescription: "This app displays the outputs from a past execution. It's useful to share the results of a flow with external stakeholders."
-  title: Getting Started with Apps - Display outputs from a past execution
+  title: Display outputs from a past execution — Getting Started with Apps
   description: |
     This app displays the outputs from a past execution. 
     

--- a/apps/simple-execution-app.yaml
+++ b/apps/simple-execution-app.yaml
@@ -53,7 +53,7 @@ layout:
         style: INFO
 extend:
   shortDescription: "This app allows you to execute a simple flow and display execution logs."
-  title: Getting Started with Apps - Create Execution from a Flow and display logs
+  title: Create Execution from a Flow and display logs — Getting Started with Apps
   description: |
     This app allows you to execute a simple flow and display execution logs.
   tags:

--- a/flows/business-automation.yaml
+++ b/flows/business-automation.yaml
@@ -54,7 +54,7 @@ description: |
 
 extend:
   shortDescription: "This flow demonstrates how to use the SQLite plugin to create a table, insert data, and query the data."
-  title: Getting started with Kestra — a Business Automation workflow example
+  title: Business Automation workflow example — Getting started with Kestra
   metaTitle: Getting started with Kestra
   description: This flow demonstrates how to use the SQLite plugin to create a
     table, insert data, and query the data. The flow then converts the query

--- a/flows/business-processes.yaml
+++ b/flows/business-processes.yaml
@@ -50,7 +50,7 @@ description: |
 
 extend:
   shortDescription: "This flow is a simple example of a business process automation use case for vacation approval."
-  title: Getting started with Kestra — a Business Processes workflow example
+  title: Business Processes workflow example — Getting started with Kestra
   metaTitle: Getting started with Kestra
   description: |
     This flow is a simple example of a business process automation use case for

--- a/flows/data-engineering-pipeline.yaml
+++ b/flows/data-engineering-pipeline.yaml
@@ -63,7 +63,7 @@ description: |
 
 extend:
   shortDescription: "This flow is a simple example of a Kestra flow used for a data engineering use case."
-  title: Getting started with Kestra — a Data Engineering Pipeline example
+  title: Data Engineering Pipeline example — Getting started with Kestra
   metaTitle: Getting started with Kestra
   description: |
     This flow is a simple example of a Kestra flow used for a data engineering

--- a/flows/hello-world.yaml
+++ b/flows/hello-world.yaml
@@ -45,7 +45,7 @@ description: |
 
 extend:
   shortDescription: "This flow is a simple example of a Kestra flow. It takes a user input and logs a welcome message. The flow has three tasks: 1."
-  title: Getting started with Kestra — a Hello World Example
+  title: Hello World Example — Getting started with Kestra
   metaTitle: Getting started with Kestra — a Hello World Example
   description: |
     This flow is a simple example of a Kestra flow. It takes a user input and

--- a/flows/infrastructure-automation.yaml
+++ b/flows/infrastructure-automation.yaml
@@ -102,7 +102,7 @@ description: |
 
 extend:
   shortDescription: "This flow is a simple example of an infrastructure automation use case."
-  title: Getting started with Kestra — an Infrastructure Automation workflow example
+  title: Infrastructure Automation workflow example — Getting started with Kestra
   metaTitle: Getting started with Kestra
   description: |
     This flow is a simple example of an infrastructure automation use case. It

--- a/flows/microservices-and-apis.yaml
+++ b/flows/microservices-and-apis.yaml
@@ -52,7 +52,7 @@ description: |
 
 extend:
   shortDescription: "This flow is a simple example of a microservices and APIs use case. It checks the health of a server and sends a Slack alert if the server is down."
-  title: Getting started with Kestra — a Microservices and APIs workflow example
+  title: Microservices and APIs workflow example — Getting started with Kestra
   metaTitle: Getting started with Kestra
   description: |
     This flow is a simple example of a microservices and APIs use case. It


### PR DESCRIPTION
Improve the readability between the `Getting Started` blueprints. Discussed with @vfanucci 