### PR TITLE
feat: IBM MQ ↔ Amazon MSK bridge via Kafka Connect

### DIFF
--- a/flows/ibm-mq-msk-kafka-connect.yaml
+++ b/flows/ibm-mq-msk-kafka-connect.yaml
@@ -1,0 +1,227 @@
+id: ibm-mq-msk-kafka-connect
+namespace: company.team
+
+variables:
+  kafka_connect_url: "http://kafka-connect:8083"
+  source_connector_name: ibmmq-source
+  sink_connector_name: ibmmq-sink
+  source_topic: mainframe.events
+  sink_topic: cloud.events
+  dlq_source_topic: mainframe.events.dlq
+  dlq_sink_topic: cloud.events.dlq
+
+tasks:
+  - id: deploy_connectors
+    type: io.kestra.plugin.core.flow.Parallel
+    tasks:
+      - id: deploy_source_connector
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ vars.kafka_connect_url }}/connectors/{{ vars.source_connector_name }}/config"
+        method: PUT
+        contentType: application/json
+        body: |
+          {
+            "connector.class": "com.ibm.eventstreams.connect.mqsource.MQSourceConnector",
+            "tasks.max": "3",
+            "mq.queue.manager": "{{ secret('IBM_MQ_QUEUE_MANAGER') }}",
+            "mq.connection.name.list": "{{ secret('IBM_MQ_HOST') }}({{ secret('IBM_MQ_PORT') }})",
+            "mq.channel.name": "{{ secret('IBM_MQ_CHANNEL') }}",
+            "mq.queue": "{{ secret('IBM_MQ_SOURCE_QUEUE') }}",
+            "mq.user.name": "{{ secret('IBM_MQ_USERNAME') }}",
+            "mq.password": "{{ secret('IBM_MQ_PASSWORD') }}",
+            "mq.ssl.cipher.suite": "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "mq.record.builder": "com.ibm.eventstreams.connect.mqsource.builders.JsonRecordBuilder",
+            "mq.message.body.jms": "true",
+            "kafka.topic": "{{ vars.source_topic }}",
+            "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+            "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "value.converter.schemas.enable": "false",
+            "producer.override.acks": "all",
+            "errors.tolerance": "all",
+            "errors.deadletterqueue.topic.name": "{{ vars.dlq_source_topic }}",
+            "errors.deadletterqueue.topic.replication.factor": "3",
+            "errors.deadletterqueue.context.headers.enable": "true",
+            "transforms": "addCloudEventsId,addCloudEventsSource",
+            "transforms.addCloudEventsId.type": "org.apache.kafka.connect.transforms.InsertField$Value",
+            "transforms.addCloudEventsId.offset.field": "ce_id",
+            "transforms.addCloudEventsSource.type": "org.apache.kafka.connect.transforms.InsertField$Value",
+            "transforms.addCloudEventsSource.static.field": "ce_source",
+            "transforms.addCloudEventsSource.static.value": "ibm-mq/mainframe"
+          }
+
+      - id: deploy_sink_connector
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ vars.kafka_connect_url }}/connectors/{{ vars.sink_connector_name }}/config"
+        method: PUT
+        contentType: application/json
+        body: |
+          {
+            "connector.class": "com.ibm.eventstreams.connect.mqsink.MQSinkConnector",
+            "tasks.max": "3",
+            "topics": "{{ vars.sink_topic }}",
+            "mq.queue.manager": "{{ secret('IBM_MQ_QUEUE_MANAGER') }}",
+            "mq.connection.name.list": "{{ secret('IBM_MQ_HOST') }}({{ secret('IBM_MQ_PORT') }})",
+            "mq.channel.name": "{{ secret('IBM_MQ_CHANNEL') }}",
+            "mq.queue": "{{ secret('IBM_MQ_SINK_QUEUE') }}",
+            "mq.user.name": "{{ secret('IBM_MQ_USERNAME') }}",
+            "mq.password": "{{ secret('IBM_MQ_PASSWORD') }}",
+            "mq.ssl.cipher.suite": "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "mq.message.builder": "com.ibm.eventstreams.connect.mqsink.builders.JsonMessageBuilder",
+            "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+            "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "value.converter.schemas.enable": "false",
+            "consumer.override.auto.offset.reset": "earliest",
+            "errors.tolerance": "all",
+            "errors.deadletterqueue.topic.name": "{{ vars.dlq_sink_topic }}",
+            "errors.deadletterqueue.topic.replication.factor": "3",
+            "errors.deadletterqueue.context.headers.enable": "true"
+          }
+
+  - id: check_connectors_health
+    type: io.kestra.plugin.core.flow.Parallel
+    tasks:
+      - id: check_source_status
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ vars.kafka_connect_url }}/connectors/{{ vars.source_connector_name }}/status"
+        method: GET
+
+      - id: check_sink_status
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ vars.kafka_connect_url }}/connectors/{{ vars.sink_connector_name }}/status"
+        method: GET
+
+  - id: log_connector_states
+    type: io.kestra.plugin.core.log.Log
+    message: |
+      Source connector state: {{ outputs.check_source_status.body | jq('.connector.state') }}
+      Sink connector state: {{ outputs.check_sink_status.body | jq('.connector.state') }}
+
+  - id: monitor_dlq
+    type: io.kestra.plugin.kafka.Consume
+    topic:
+      - "{{ vars.dlq_source_topic }}"
+      - "{{ vars.dlq_sink_topic }}"
+    properties:
+      bootstrap.servers: "{{ secret('MSK_BOOTSTRAP_SERVERS') }}"
+      security.protocol: SASL_SSL
+      sasl.mechanism: AWS_MSK_IAM
+      sasl.jaas.config: software.amazon.msk.auth.iam.IAMLoginModule required;
+      sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+    keyDeserializer: STRING
+    valueDeserializer: STRING
+    maxRecords: 1000
+    groupId: kestra-dlq-monitor-{{ execution.id }}
+
+  - id: alert_on_dlq
+    type: io.kestra.plugin.core.log.Log
+    level: WARN
+    message: "{{ outputs.monitor_dlq.messagesCount }} failed events in DLQ — replay required."
+    runIf: "{{ outputs.monitor_dlq.messagesCount > 0 }}"
+
+triggers:
+  - id: daily_health_check
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 8 * * *"
+
+extend:
+  shortDescription: "Deploy and monitor Kafka Connect as a bidirectional bridge between IBM MQ (mainframe) and Amazon MSK, enabling real-time event streaming without touching COBOL."
+  title: Bridge IBM Mainframe MQ to Amazon MSK with Kafka Connect
+  metaTitle: IBM MQ ↔ Amazon MSK Event Bridge via Kafka Connect
+  description: |
+    This flow deploys and monitors **Kafka Connect as a bidirectional bridge**
+    between IBM MQ on a z/OS mainframe and Amazon MSK, enabling real-time event
+    streaming to cloud applications without modifying any COBOL code.
+
+    ## Context
+
+    In banking and insurance environments, 80-90% of business data lives in
+    mainframe systems. Traditionally, cloud applications access this data through
+    nightly batch exports, resulting in J+1 visibility — advisors and apps see
+    yesterday's data. When a record fails, you wait until the next batch run.
+
+    This architecture replaces batch with **event-driven streaming** at the
+    infrastructure level:
+
+    - **Source connector**: IBM MQ → Kafka topic on MSK (mainframe events reach
+      cloud consumers in seconds)
+    - **Sink connector**: Kafka topic on MSK → IBM MQ (cloud events flow back to
+      mainframe queues with transactional guarantees)
+    - **No COBOL changes**: the COBOL programs keep writing to MQ queues — Kafka
+      Connect reads from and writes to those queues transparently
+
+    ## Architecture
+
+    The connectors use the IBM open-source Kafka Connect plugins:
+
+    - Source: `kafka-connect-mq-source`
+      (github.com/ibm-messaging/kafka-connect-mq-source)
+    - Sink: `kafka-connect-mq-sink`
+      (github.com/ibm-messaging/kafka-connect-mq-sink)
+
+    Both connectors are deployed idempotently via the Kafka Connect REST API
+    (`PUT /connectors/{name}/config`), so re-running this flow is safe — it
+    updates the config if the connector already exists.
+
+    ## Reliability guarantees
+
+    - **At-least-once delivery**: source connector commits offsets only after
+      MSK acknowledges (`producer.override.acks=all`); sink connector reads
+      from committed offsets only
+    - **DLQ (Dead Letter Queue)**: serialization or connectivity failures are
+      routed to `*.dlq` topics with full error context headers for replay
+    - **3-AZ replication**: DLQ topics are created with
+      `replication.factor=3` to survive an availability zone failure
+
+    ## EBCDIC → JSON
+
+    The `JsonRecordBuilder` on the source connector handles EBCDIC character
+    set conversion automatically when `mq.message.body.jms=true`. For binary
+    COBOL copybook formats, replace with `DefaultRecordBuilder` and add a
+    downstream Kestra flow to apply the COBOL-to-JSON transformation using a
+    custom script or the `plugin-serdes` tools.
+
+    ## CloudEvents compliance
+
+    The source connector is configured with two SMTs (Single Message
+    Transforms) that inject `ce_id` and `ce_source` fields to align with
+    the CloudEvents specification and AsyncAPI contracts, making downstream
+    consumers schema-aware.
+
+    ## Secrets
+
+    Configure the following secrets in Kestra before running:
+
+    - `IBM_MQ_QUEUE_MANAGER`: MQ queue manager name (e.g., `QM1`)
+    - `IBM_MQ_HOST`: MQ server hostname or IP
+    - `IBM_MQ_PORT`: MQ listener port (default `1414`)
+    - `IBM_MQ_CHANNEL`: MQ server-connection channel (e.g., `DEV.APP.SVRCONN`)
+    - `IBM_MQ_SOURCE_QUEUE`: queue the mainframe writes events to
+    - `IBM_MQ_SINK_QUEUE`: queue the mainframe reads cloud responses from
+    - `IBM_MQ_USERNAME`: MQ application user
+    - `IBM_MQ_PASSWORD`: MQ application password
+    - `MSK_BOOTSTRAP_SERVERS`: MSK broker endpoints (comma-separated)
+
+    ## Prerequisites
+
+    1. A Kafka Connect cluster (self-managed or Amazon MSK Connect) with the
+       IBM MQ source and sink JARs deployed in the plugin path
+    2. IBM MQ accessible from the Kafka Connect workers (VPN, Direct Connect,
+       or Transit Gateway)
+    3. An IAM role or SASL/SCRAM credentials attached to the Kafka Connect
+       workers for MSK authentication
+    4. MSK topics pre-created with `replication.factor=3` and the appropriate
+       retention policy
+
+    ## Scheduling
+
+    The flow runs daily at 08:00 to redeploy connectors (idempotent) and check
+    their health. Connector state and DLQ depth are logged for monitoring.
+    Wire the `alert_on_dlq` task to a Slack or PagerDuty notification for
+    production use.
+  tags:
+    - Cloud
+    - Data
+    - Infrastructure
+  ee: false
+  demo: false
+  metaDescription: Deploy Kafka Connect as a bidirectional IBM MQ ↔ Amazon MSK bridge. Stream mainframe events to the cloud in real time without touching COBOL, with DLQ, at-least-once delivery, and CloudEvents compliance.


### PR DESCRIPTION
## Use case

> Comment brancher un mainframe IBM sur de l'event-driven ?
> Kafka Connect entre IBM MQ et Amazon MSK.

Bancassurance context: 80-90% of business data lives in the mainframe. Nightly batch exports give J+1 visibility to cloud apps — this blueprint replaces that with real-time event streaming, zero COBOL changes.

## What this blueprint does

Deploys and monitors **Kafka Connect as a bidirectional bridge** between IBM MQ (z/OS) and Amazon MSK:

- **Source connector** — IBM MQ → MSK Kafka topic (`mainframe.events`): mainframe events reach cloud consumers in seconds instead of 24h+
- **Sink connector** — MSK Kafka topic → IBM MQ (`cloud.events`): cloud responses flow back to mainframe queues with transactional guarantees
- **Daily health check** (scheduled at 08:00): redeploys connectors (idempotent `PUT`) and reports connector state + DLQ depth

## Reliability guarantees covered

| Requirement | Implementation |
|---|---|
| At-least-once | `acks=all` on source, committed-only reads on sink |
| DLQ | `errors.deadletterqueue.*` on both connectors, 3x replication |
| CloudEvents | Two SMTs inject `ce_id` and `ce_source` fields |
| EBCDIC → JSON | `JsonRecordBuilder` + `mq.message.body.jms=true` |
| 3-AZ replication | DLQ topics created with `replication.factor=3` |

## Plugins used

- `io.kestra.plugin.core.http.Request` — Kafka Connect REST API (`PUT /connectors/{name}/config`, `GET /connectors/{name}/status`)
- `io.kestra.plugin.kafka.Consume` — DLQ monitoring on MSK
- `io.kestra.plugin.core.flow.Parallel` — concurrent connector deployment and health checks
- `io.kestra.plugin.core.trigger.Schedule` — daily 08:00 health check

No IBM MQ native plugin exists in Kestra; the Kafka Connect REST API is the standard production interface for managing connectors.

## Test plan

- [ ] YAML is valid and parses without errors
- [ ] `PUT /connectors/{name}/config` is idempotent (safe to re-run)
- [ ] Secrets list is complete and clearly documented
- [ ] Description covers prerequisites, EBCDIC handling, CloudEvents, and DLQ replay path

🤖 Generated with [Claude Code](https://claude.com/claude-code)