### PR TITLE
feat: add Microsoft Fabric blueprints

### DIFF
--- a/flows/fabric-end-to-end-pipeline.yaml
+++ b/flows/fabric-end-to-end-pipeline.yaml
@@ -1,0 +1,114 @@
+id: fabric-end-to-end-pipeline
+namespace: company.team
+
+variables:
+  workspace_id: your-workspace-guid
+  lakehouse_id: your-lakehouse-guid
+  pipeline_id: your-ingestion-pipeline-guid
+  notebook_id: your-transform-notebook-guid
+  sql_endpoint_id: your-sql-endpoint-id
+  warehouse_id: your-warehouse-guid
+
+tasks:
+  - id: run_ingestion_pipeline
+    type: io.kestra.plugin.microsoft.fabric.data.engineering.RunPipeline
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    pipelineId: "{{ vars.pipeline_id }}"
+    parameters:
+      load_date: "{{ now() | dateFormat('yyyy-MM-dd') }}"
+    wait: true
+    pollFrequency: PT15S
+    timeout: PT1H
+
+  - id: run_transform_notebook
+    type: io.kestra.plugin.microsoft.fabric.data.engineering.RunNotebook
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    notebookId: "{{ vars.notebook_id }}"
+    parameters:
+      load_date: "{{ now() | dateFormat('yyyy-MM-dd') }}"
+      source_layer: bronze
+      target_layer: silver
+    wait: true
+    pollFrequency: PT20S
+    timeout: PT2H
+
+  - id: validate_results
+    type: io.kestra.plugin.microsoft.fabric.warehouse.Query
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    sqlEndpointId: "{{ vars.sql_endpoint_id }}"
+    warehouseId: "{{ vars.warehouse_id }}"
+    fetchType: FETCH_ONE
+    sql: |
+      SELECT COUNT(*) AS row_count
+      FROM silver.fact_orders
+      WHERE load_date = CAST('{{ now() | dateFormat('yyyy-MM-dd') }}' AS DATE)
+
+  - id: log_validation
+    type: io.kestra.plugin.core.log.Log
+    message: "Silver layer loaded {{ outputs.validate_results.row.row_count }} rows for today."
+
+errors:
+  - id: on_failure
+    type: io.kestra.plugin.core.log.Log
+    level: ERROR
+    message: "Fabric pipeline failed at task: {{ task.id }}. Check execution logs for details."
+
+triggers:
+  - id: nightly
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: 0 2 * * *
+
+extend:
+  title: End-to-End Fabric Orchestration — Ingest, Transform, and Validate
+  shortDescription: Run a Fabric ingestion pipeline, transform data with a Notebook, and validate results in the Warehouse — all from a single Kestra flow.
+  metaTitle: End-to-End Microsoft Fabric Orchestration with Kestra
+  description: |
+    This blueprint orchestrates a **complete Microsoft Fabric data pipeline**
+    — from raw ingestion through transformation to validation — using a single
+    Kestra flow on a nightly schedule.
+
+    The workflow operates as follows:
+
+    1. **Ingest** — triggers a Fabric Data Pipeline to load raw data into the
+       Bronze Lakehouse layer, passing the current date as a parameter.
+    2. **Transform** — runs a Fabric Notebook to clean and conform the Bronze
+       data into the Silver layer, passing source/target layer parameters.
+    3. **Validate** — queries the Fabric Warehouse to count the rows written to
+       the Silver fact table and logs the result.
+    4. **Alert on failure** — the `errors` block logs a structured error
+       message if any step fails, making it easy to hook in Slack or email
+       notifications.
+
+    This pattern is ideal for:
+      - Nightly batch pipelines that span multiple Fabric workloads
+      - Medallion architecture implementations (Bronze → Silver) orchestrated
+        from a central scheduler
+      - Teams who want retries, timeout handling, and observability for Fabric
+        jobs without custom scripting
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, and
+        `FABRIC_CLIENT_SECRET` as Kestra secrets.
+      - Replace all variable GUIDs with your actual Fabric workspace, Lakehouse,
+        pipeline, notebook, and warehouse identifiers.
+      - Tune `pollFrequency` and `timeout` for each step to match typical run
+        durations.
+      - Replace the `on_failure` Log task with a Slack or email task to receive
+        failure alerts.
+
+    This blueprint provides a production-ready foundation for **end-to-end
+    Fabric pipeline orchestration** with full observability from Kestra.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Orchestrate a full Microsoft Fabric pipeline in Kestra — trigger ingestion, run a Notebook transformation, validate results in the Warehouse, and alert on failure.

--- a/flows/fabric-end-to-end-pipeline.yaml
+++ b/flows/fabric-end-to-end-pipeline.yaml
@@ -108,7 +108,6 @@ extend:
     Fabric pipeline orchestration** with full observability from Kestra.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Orchestrate a full Microsoft Fabric pipeline in Kestra — trigger ingestion, run a Notebook transformation, validate results in the Warehouse, and alert on failure.

--- a/flows/fabric-onelake-download-and-process.yaml
+++ b/flows/fabric-onelake-download-and-process.yaml
@@ -81,7 +81,6 @@ extend:
     processing pipelines** combining Kestra, Fabric, and Python.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Download files from Microsoft Fabric OneLake, process them with Python, and upload results back to a Fabric Lakehouse using Kestra.

--- a/flows/fabric-onelake-download-and-process.yaml
+++ b/flows/fabric-onelake-download-and-process.yaml
@@ -1,0 +1,87 @@
+id: fabric-onelake-download-and-process
+namespace: company.team
+
+variables:
+  workspace_id: your-workspace-guid
+  lakehouse_id: your-lakehouse-guid
+  input_path: silver/features/latest.parquet
+
+tasks:
+  - id: download_from_onelake
+    type: io.kestra.plugin.microsoft.fabric.onelake.Download
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    itemId: "{{ vars.lakehouse_id }}"
+    filePath: "{{ vars.input_path }}"
+
+  - id: process
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      input.parquet: "{{ outputs.download_from_onelake.uri }}"
+    outputFiles:
+      - report.csv
+    taskRunner:
+      type: io.kestra.plugin.scripts.runner.docker.Docker
+    dependencies:
+      - pandas
+      - pyarrow
+    script: |
+      import pandas as pd
+      df = pd.read_parquet("input.parquet")
+      summary = df.describe().reset_index()
+      summary.to_csv("report.csv", index=False)
+
+  - id: upload_report
+    type: io.kestra.plugin.microsoft.fabric.onelake.Upload
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    itemId: "{{ vars.lakehouse_id }}"
+    from: "{{ outputs.process.outputFiles['report.csv'] }}"
+    filePath: "reports/{{ now() | dateFormat('yyyy-MM-dd') }}/report.csv"
+
+extend:
+  title: Download from OneLake, Process with Python, and Upload Back
+  shortDescription: Download a file from a Fabric Lakehouse, transform it with Python, and upload the result back to OneLake.
+  metaTitle: Process Microsoft Fabric OneLake Files with Python in Kestra
+  description: |
+    This blueprint downloads a file from a **Microsoft Fabric Lakehouse via
+    OneLake**, transforms it using Python, and uploads the result back to the
+    same Lakehouse.
+
+    The workflow operates as follows:
+
+    - Downloads a Parquet file from the Lakehouse `Files/` directory into
+      Kestra internal storage.
+    - Passes the file to a Python script running in a Docker container for
+      transformation using Pandas and PyArrow.
+    - Uploads the processed CSV report back to OneLake in a date-partitioned
+      output path.
+
+    This pattern is ideal for:
+      - Post-processing Fabric-managed datasets with custom Python logic
+        outside of Spark or Notebooks
+      - Generating summary reports or quality checks from OneLake files as
+        part of a broader orchestration flow
+      - Lightweight ETL that reads from OneLake, transforms in-process, and
+        writes results back
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, and
+        `FABRIC_CLIENT_SECRET` as Kestra secrets.
+      - Replace `workspace_id` and `lakehouse_id` with your Fabric GUIDs.
+      - Set `input_path` to the relative path inside the Lakehouse `Files/`
+        directory.
+      - Adjust the Python script and dependencies for your transformation logic.
+
+    This blueprint provides a production-ready foundation for **OneLake file
+    processing pipelines** combining Kestra, Fabric, and Python.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Download files from Microsoft Fabric OneLake, process them with Python, and upload results back to a Fabric Lakehouse using Kestra.

--- a/flows/fabric-onelake-upload.yaml
+++ b/flows/fabric-onelake-upload.yaml
@@ -1,0 +1,74 @@
+id: fabric-onelake-upload
+namespace: company.team
+
+variables:
+  workspace_id: your-workspace-guid
+  lakehouse_id: your-lakehouse-guid
+
+tasks:
+  - id: extract
+    type: io.kestra.plugin.jdbc.postgresql.CopyOut
+    sql: SELECT * FROM orders WHERE created_at::date = current_date - 1
+    format: CSV
+    header: true
+
+  - id: upload_to_onelake
+    type: io.kestra.plugin.microsoft.fabric.onelake.Upload
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    itemId: "{{ vars.lakehouse_id }}"
+    from: "{{ outputs.extract.uri }}"
+    filePath: "raw/orders/{{ now() | dateFormat('yyyy-MM-dd') }}/orders.csv"
+
+pluginDefaults:
+  - type: io.kestra.plugin.jdbc.postgresql.CopyOut
+    values:
+      url: jdbc:postgresql://your-db-host:5432/your-db
+      username: your-db-user
+      password: "{{ secret('DB_PASSWORD') }}"
+
+extend:
+  title: Export a Database Table to Microsoft Fabric OneLake
+  shortDescription: Query a database, then upload the result as a CSV file to a Fabric Lakehouse via OneLake.
+  metaTitle: Export Database Data to Microsoft Fabric OneLake with Kestra
+  description: |
+    This blueprint extracts data from a relational database and uploads the
+    result as a CSV file to a **Microsoft Fabric Lakehouse via OneLake**.
+
+    The workflow operates as follows:
+
+    - Runs a SQL query against a PostgreSQL database using the JDBC CopyOut task
+      and stores the result as a CSV file in Kestra internal storage.
+    - Uploads the CSV file to the `Files/` directory of the specified Lakehouse
+      using the Fabric OneLake ADLS Gen2 API.
+    - Organises uploaded files in a date-partitioned folder structure.
+    - Exposes the `uri` (ABFSS path in OneLake) as a task output for downstream
+      Fabric jobs.
+
+    This pattern is ideal for:
+      - Daily or incremental data exports from operational databases into a
+        Fabric Lakehouse landing zone
+      - Building Bronze-layer ingestion pipelines for medallion architectures
+        in Microsoft Fabric
+      - Staging data in OneLake before triggering a Fabric Notebook or Spark
+        job for transformation
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, `FABRIC_CLIENT_SECRET`,
+        and `DB_PASSWORD` as Kestra secrets.
+      - Replace `workspace_id` and `lakehouse_id` with your Fabric GUIDs.
+      - Adjust the SQL query and `filePath` to match your schema and partition
+        strategy.
+      - Replace the PostgreSQL `pluginDefaults` with your actual database type
+        and connection details.
+
+    This blueprint provides a production-ready foundation for **database-to-
+    OneLake ingestion pipelines** within Kestra flows.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Export database query results to Microsoft Fabric OneLake with Kestra. Upload CSV files to a Fabric Lakehouse and build Bronze-layer ingestion pipelines.

--- a/flows/fabric-onelake-upload.yaml
+++ b/flows/fabric-onelake-upload.yaml
@@ -68,7 +68,6 @@ extend:
     OneLake ingestion pipelines** within Kestra flows.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Export database query results to Microsoft Fabric OneLake with Kestra. Upload CSV files to a Fabric Lakehouse and build Bronze-layer ingestion pipelines.

--- a/flows/fabric-run-data-pipeline.yaml
+++ b/flows/fabric-run-data-pipeline.yaml
@@ -58,7 +58,6 @@ extend:
     pipeline orchestration** within Kestra flows.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Trigger a Microsoft Fabric Data Pipeline from Kestra, pass dynamic parameters, poll for completion, and chain results with downstream tasks.

--- a/flows/fabric-run-data-pipeline.yaml
+++ b/flows/fabric-run-data-pipeline.yaml
@@ -1,0 +1,64 @@
+id: fabric-run-data-pipeline
+namespace: company.team
+
+variables:
+  workspace_id: your-workspace-guid
+  pipeline_id: your-pipeline-guid
+
+tasks:
+  - id: run_pipeline
+    type: io.kestra.plugin.microsoft.fabric.data.engineering.RunPipeline
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    pipelineId: "{{ vars.pipeline_id }}"
+    parameters:
+      environment: production
+      date: "{{ now() | dateFormat('yyyy-MM-dd') }}"
+    wait: true
+    pollFrequency: PT10S
+    timeout: PT2H
+
+extend:
+  title: Run a Microsoft Fabric Data Pipeline
+  shortDescription: Trigger a Fabric Data Pipeline job with parameters and wait for completion.
+  metaTitle: Run a Microsoft Fabric Data Pipeline with Kestra
+  description: |
+    This blueprint triggers a **Microsoft Fabric Data Pipeline** job and waits
+    for it to reach a terminal state before the flow continues.
+
+    The workflow operates as follows:
+
+    - Authenticates to Microsoft Fabric using a service principal (tenant ID,
+      client ID, and client secret stored as Kestra secrets).
+    - Submits the pipeline job via the Fabric REST API with the provided
+      key/value parameters.
+    - Polls the job status at the configured interval until the pipeline
+      completes, fails, is cancelled, or is deduped.
+    - Surfaces the final `status` and `runId` as task outputs for downstream
+      tasks or notifications.
+
+    This pattern is ideal for:
+      - Orchestrating Fabric pipelines from a central Kestra workflow
+      - Passing dynamic parameters (date, environment, etc.) to pipeline runs
+      - Chaining Fabric pipeline execution with upstream data preparation or
+        downstream reporting tasks
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, and
+        `FABRIC_CLIENT_SECRET` as Kestra secrets.
+      - Replace `workspace_id` and `pipeline_id` with your actual GUIDs from
+        the Fabric portal.
+      - Adjust `pollFrequency` and `timeout` to match your pipeline's typical
+        run duration.
+      - Set `wait: false` to fire-and-forget and continue the flow immediately.
+
+    This blueprint provides a production-ready foundation for **native Fabric
+    pipeline orchestration** within Kestra flows.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Trigger a Microsoft Fabric Data Pipeline from Kestra, pass dynamic parameters, poll for completion, and chain results with downstream tasks.

--- a/flows/fabric-run-notebook.yaml
+++ b/flows/fabric-run-notebook.yaml
@@ -1,0 +1,63 @@
+id: fabric-run-notebook
+namespace: company.team
+
+variables:
+  workspace_id: your-workspace-guid
+  notebook_id: your-notebook-guid
+
+tasks:
+  - id: run_notebook
+    type: io.kestra.plugin.microsoft.fabric.data.engineering.RunNotebook
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    notebookId: "{{ vars.notebook_id }}"
+    parameters:
+      input_date: "{{ now() | dateFormat('yyyy-MM-dd') }}"
+      output_table: silver.cleaned_events
+    wait: true
+    pollFrequency: PT15S
+    timeout: PT1H
+
+extend:
+  title: Run a Microsoft Fabric Notebook
+  shortDescription: Submit a Fabric Notebook job with parameters and wait for completion.
+  metaTitle: Run a Microsoft Fabric Notebook with Kestra
+  description: |
+    This blueprint submits a **Microsoft Fabric Notebook** job and waits for
+    it to finish before the flow proceeds.
+
+    The workflow operates as follows:
+
+    - Authenticates to Microsoft Fabric using a service principal stored as
+      Kestra secrets.
+    - Submits the notebook via the Fabric item job scheduler API with the
+      provided key/value parameters.
+    - Polls the job status at the configured interval until the notebook
+      reaches a terminal state (Completed, Failed, Cancelled, or Deduped).
+    - Exposes `jobInstanceId` and `status` as outputs for downstream tasks or
+      alerting.
+
+    This pattern is ideal for:
+      - Running data transformation or feature engineering notebooks on a
+        schedule or in response to upstream events
+      - Passing dynamic inputs (date ranges, target tables, model parameters)
+        to notebooks
+      - Integrating Fabric Notebook execution into multi-step Kestra pipelines
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, and
+        `FABRIC_CLIENT_SECRET` as Kestra secrets.
+      - Replace `workspace_id` and `notebook_id` with your actual Fabric GUIDs.
+      - Tune `pollFrequency` and `timeout` to your notebook's typical duration.
+      - Add error tasks under `errors:` to send alerts when the notebook fails.
+
+    This blueprint provides a production-ready foundation for **Fabric Notebook
+    orchestration** with full observability from Kestra.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Submit a Microsoft Fabric Notebook job from Kestra, pass dynamic parameters, poll for completion, and integrate results into multi-step data pipelines.

--- a/flows/fabric-run-notebook.yaml
+++ b/flows/fabric-run-notebook.yaml
@@ -57,7 +57,6 @@ extend:
     orchestration** with full observability from Kestra.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Submit a Microsoft Fabric Notebook job from Kestra, pass dynamic parameters, poll for completion, and integrate results into multi-step data pipelines.

--- a/flows/fabric-run-spark-job.yaml
+++ b/flows/fabric-run-spark-job.yaml
@@ -1,0 +1,61 @@
+id: fabric-run-spark-job
+namespace: company.team
+
+variables:
+  workspace_id: your-workspace-guid
+  spark_job_definition_id: your-spark-job-definition-guid
+
+tasks:
+  - id: run_spark_job
+    type: io.kestra.plugin.microsoft.fabric.data.engineering.RunSparkJob
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    workspaceId: "{{ vars.workspace_id }}"
+    sparkJobDefinitionId: "{{ vars.spark_job_definition_id }}"
+    wait: true
+    pollFrequency: PT30S
+    timeout: PT4H
+
+extend:
+  title: Run a Microsoft Fabric Spark Job
+  shortDescription: Submit a Fabric Spark Job Definition and wait for completion.
+  metaTitle: Run a Microsoft Fabric Spark Job with Kestra
+  description: |
+    This blueprint submits a **Microsoft Fabric Spark Job Definition** and
+    waits for it to complete before the flow continues.
+
+    The workflow operates as follows:
+
+    - Authenticates to Microsoft Fabric using a service principal stored as
+      Kestra secrets.
+    - Submits the Spark job via the Fabric item job scheduler API.
+    - Polls the job status at the configured interval until the Spark job
+      reaches a terminal state (Completed, Failed, Cancelled, or Deduped).
+    - Exposes `jobInstanceId` and `status` as outputs for downstream tasks or
+      alerting.
+
+    This pattern is ideal for:
+      - Scheduling large-scale Spark batch processing jobs within a Kestra flow
+      - Chaining Spark job execution with upstream ingestion steps or downstream
+        reporting and notification tasks
+      - Managing long-running Spark workloads with Kestra's built-in retry and
+        timeout handling
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, and
+        `FABRIC_CLIENT_SECRET` as Kestra secrets.
+      - Replace `workspace_id` and `spark_job_definition_id` with your Fabric
+        GUIDs from the Fabric portal.
+      - Increase `pollFrequency` and `timeout` for large Spark workloads that
+        run for hours.
+      - Add error tasks under `errors:` to send alerts on job failure.
+
+    This blueprint provides a production-ready foundation for **Fabric Spark
+    job orchestration** with full observability from Kestra.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Submit a Microsoft Fabric Spark Job Definition from Kestra, poll for completion, and chain results with downstream data pipeline tasks.

--- a/flows/fabric-run-spark-job.yaml
+++ b/flows/fabric-run-spark-job.yaml
@@ -55,7 +55,6 @@ extend:
     job orchestration** with full observability from Kestra.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Submit a Microsoft Fabric Spark Job Definition from Kestra, poll for completion, and chain results with downstream data pipeline tasks.

--- a/flows/fabric-warehouse-query.yaml
+++ b/flows/fabric-warehouse-query.yaml
@@ -1,0 +1,84 @@
+id: fabric-warehouse-query
+namespace: company.team
+
+variables:
+  sql_endpoint_id: your-sql-endpoint-id
+  warehouse_id: your-warehouse-guid
+
+tasks:
+  - id: query_warehouse
+    type: io.kestra.plugin.microsoft.fabric.warehouse.Query
+    tenantId: "{{ secret('FABRIC_TENANT_ID') }}"
+    clientId: "{{ secret('FABRIC_CLIENT_ID') }}"
+    clientSecret: "{{ secret('FABRIC_CLIENT_SECRET') }}"
+    sqlEndpointId: "{{ vars.sql_endpoint_id }}"
+    warehouseId: "{{ vars.warehouse_id }}"
+    fetchType: STORE
+    sql: |
+      SELECT
+        product_category,
+        SUM(revenue)  AS total_revenue,
+        COUNT(*)      AS order_count
+      FROM sales.orders
+      WHERE order_date >= DATEADD(day, -30, GETDATE())
+      GROUP BY product_category
+      ORDER BY total_revenue DESC
+
+  - id: notify
+    type: io.kestra.plugin.core.log.Log
+    message: "Query returned {{ outputs.query_warehouse.size }} rows. Results stored at {{ outputs.query_warehouse.uri }}"
+
+triggers:
+  - id: daily
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: 0 6 * * *
+
+extend:
+  title: Query a Microsoft Fabric Warehouse
+  shortDescription: Run a T-SQL query against a Fabric Warehouse and store the results in Kestra internal storage.
+  metaTitle: Query Microsoft Fabric Warehouse with T-SQL in Kestra
+  description: |
+    This blueprint runs a **T-SQL query against a Microsoft Fabric Warehouse**
+    on a daily schedule and stores the results in Kestra internal storage.
+
+    The workflow operates as follows:
+
+    - Authenticates to the Fabric Warehouse using a service principal and
+      obtains an access token for the JDBC connection.
+    - Executes the SQL statement against the specified Warehouse endpoint and
+      stores the result set as an ION file in Kestra internal storage
+      (`fetchType: STORE`).
+    - Logs the row count and storage URI for downstream tasks.
+    - Runs automatically every morning at 06:00 via the built-in scheduler.
+
+    `fetchType` options:
+      - `STORE` — writes results to Kestra internal storage; use for large
+        result sets or when passing data to downstream tasks.
+      - `FETCH` — returns rows as an in-memory list; use for small result sets
+        or branching logic.
+      - `FETCH_ONE` — returns a single row; use for scalar lookups.
+      - `NONE` — executes the statement without fetching results; use for DML.
+
+    This pattern is ideal for:
+      - Scheduled reporting queries against a Fabric Warehouse
+      - Data quality checks that count rows or validate aggregates
+      - Extracting Warehouse data for downstream tasks (email, Slack, S3 export)
+      - Running DDL or DML statements as part of a transformation pipeline
+
+    Configuration:
+      - Store `FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, and
+        `FABRIC_CLIENT_SECRET` as Kestra secrets.
+      - Find `sqlEndpointId` on the Fabric portal under your Warehouse's
+        connection settings (the server name prefix before
+        `.datawarehouse.fabric.microsoft.com`).
+      - Replace `warehouse_id` with the Warehouse item GUID.
+      - Adjust the SQL query and schedule cron expression as needed.
+
+    This blueprint provides a production-ready foundation for **scheduled T-SQL
+    reporting and data extraction** from Microsoft Fabric Warehouse.
+  tags:
+    - Data
+    - Azure
+  ee: false
+  demo: false
+  metaDescription: Run T-SQL queries against a Microsoft Fabric Warehouse with Kestra. Schedule reports, run data quality checks, and store results for downstream processing.

--- a/flows/fabric-warehouse-query.yaml
+++ b/flows/fabric-warehouse-query.yaml
@@ -78,7 +78,6 @@ extend:
     reporting and data extraction** from Microsoft Fabric Warehouse.
   tags:
     - Data
-    - Azure
   ee: false
   demo: false
   metaDescription: Run T-SQL queries against a Microsoft Fabric Warehouse with Kestra. Schedule reports, run data quality checks, and store results for downstream processing.


### PR DESCRIPTION
## Summary

- Adds 7 blueprints covering the full public surface of the `io.kestra.plugin.microsoft.fabric` plugin
- Each blueprint uses `secret()` for credentials and includes complete `extend` metadata (title, description, tags, SEO fields)
- All blueprints use service principal authentication (`FABRIC_TENANT_ID`, `FABRIC_CLIENT_ID`, `FABRIC_CLIENT_SECRET`)

## Blueprints included

| File | What it demonstrates |
|------|----------------------|
| `fabric-run-data-pipeline.yaml` | Trigger a Fabric Data Pipeline with key/value parameters and wait for completion |
| `fabric-run-notebook.yaml` | Submit a Fabric Notebook job with parameters and poll until terminal |
| `fabric-run-spark-job.yaml` | Submit a Fabric Spark Job Definition and wait |
| `fabric-onelake-upload.yaml` | Export a PostgreSQL query result as CSV to a Fabric Lakehouse via OneLake |
| `fabric-onelake-download-and-process.yaml` | Download a Parquet file from OneLake, process with Python/Pandas, upload report back |
| `fabric-warehouse-query.yaml` | Scheduled T-SQL query against a Fabric Warehouse with `fetchType` options explained |
| `fabric-end-to-end-pipeline.yaml` | Full medallion orchestration — Data Pipeline (ingest) → Notebook (transform) → Warehouse query (validate) with error handler |

## Test plan

- [ ] YAML is valid and parses without errors
- [ ] All task type FQCNs match classes in `plugin-microsoft-fabric` (`io.kestra.plugin.microsoft.fabric.*`)
- [ ] Secret references follow the `{{ secret('...') }}` convention used across the blueprints repo
- [ ] `extend` block is present and complete on every file (title, shortDescription, metaTitle, description, tags, ee, demo, metaDescription)