### PR TITLE
fix(blueprints): replace removed fetchType to stop /blueprints/* 500s

### DIFF
--- a/flows/datagen-mongodb.yaml
+++ b/flows/datagen-mongodb.yaml
@@ -6,7 +6,7 @@ tasks:
   - id: datagen
     type: io.kestra.plugin.datagen.core.Generate
     batchSize: 100
-    fetchType: STORE
+    store: true
     generator:
       type: io.kestra.plugin.datagen.generators.JsonObjectGenerator
       locale: ["us", "US"]

--- a/flows/gsheet-to-bigquery.yaml
+++ b/flows/gsheet-to-bigquery.yaml
@@ -48,8 +48,8 @@ extend:
 
     The flow performs the following tasks:
 
-    1. Reads the Google Sheet and stores the results in Kestra's internal
-    storage (fetchType: STORE).
+    1. Reads the Google Sheet and fetches the results into Kestra's internal
+    storage (`fetch: true`).
     2. The file in the internal storage is then converted into a CSV file.
     3. The CSV file is loaded into BigQuery.
   tags:


### PR DESCRIPTION
## Summary
- Two blueprint pages return HTTP 500 in production because the API's `/graph` endpoint rejects the flows with a 422 (the Astro `[id].astro` page doesn't catch that call).
- Root cause: the `fetchType` property no longer exists on `io.kestra.plugin.datagen.core.Generate` nor on `io.kestra.plugin.googleworkspace.sheets.Read`.

Fixes:
- `flows/datagen-mongodb.yaml`: `fetchType: STORE` → `store: true`
- `flows/gsheet-to-bigquery.yaml`: description text aligned to current `fetch: true` (the flow field itself was already corrected in #?, this only touches the docs string)

## Repro before fix
```
curl -s https://api.kestra.io/v1/blueprints/datagen-mongodb/versions/latest/graph
# => 422 "Unrecognized field \"fetchType\" (class ...Generate)"
curl -sI https://kestra.io/blueprints/datagen-mongodb
# => HTTP/2 500
```

## Test plan
- [ ] After deploy, `GET /v1/blueprints/datagen-mongodb/versions/latest/graph` returns 200
- [ ] After deploy, `GET /v1/blueprints/gsheet-to-bigquery/versions/latest/graph` returns 200
- [ ] `https://kestra.io/blueprints/datagen-mongodb` returns 200
- [ ] `https://kestra.io/blueprints/gsheet-to-bigquery` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)