### PR TITLE
fix(blueprints): make system flows validate on Kestra 2.0

### DIFF
--- a/flows/copy-flows-to-new-tenant.yaml
+++ b/flows/copy-flows-to-new-tenant.yaml
@@ -28,7 +28,6 @@ tasks:
 
 pluginDefaults:
   - type: io.kestra.plugin.core.http
-    forced: true
     values:
       retry:
         type: constant

--- a/flows/create-hubspot-ticket-on-failure.yaml
+++ b/flows/create-hubspot-ticket-on-failure.yaml
@@ -4,7 +4,7 @@ namespace: system
 tasks:
   - id: create_ticket
     type: io.kestra.plugin.hubspot.tickets.Create
-    apiKey: my_api_key
+    apiKey: "{{ secret('HUBSPOT_API_KEY') }}"
     subject: Workflow failed
     content: "{{ trigger.executionId }} has failed on {{ taskrun.startDate }}"
     stage: 3
@@ -13,14 +13,10 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
-      - type: io.kestra.plugin.core.condition.ExecutionNamespace
-        namespace: company
-        comparison: PREFIX
+    states:
+      - FAILED
+      - WARNING
+    when: "{{ flow.namespace | startsWith('company') }}"
 
 extend:
   shortDescription: "This system blueprint implements an incident management and customer support integration pattern by automatically creating HubSpot tickets whenever a Kestra."

--- a/flows/create-linear-issue-on-failure.yaml
+++ b/flows/create-linear-issue-on-failure.yaml
@@ -4,7 +4,7 @@ namespace: system
 tasks:
   - id: linear
     type: io.kestra.plugin.linear.issues.Create
-    token: your_api_token
+    token: "{{ secret('LINEAR_API_TOKEN') }}"
     team: MyTeamName
     title: Workflow failed
     description: "{{ trigger.executionId }} has failed on {{ taskrun.startDate }}.
@@ -16,14 +16,10 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
-      - type: io.kestra.plugin.core.condition.ExecutionNamespace
-        namespace: company
-        comparison: PREFIX
+    states:
+      - FAILED
+      - WARNING
+    when: "{{ flow.namespace | startsWith('company') }}"
 
 extend:
   shortDescription: "This system blueprint implements an incident management and monitoring pattern by automatically creating Linear issues whenever a Kestra workflow execution."

--- a/flows/failure-alert-discord.yaml
+++ b/flows/failure-alert-discord.yaml
@@ -10,11 +10,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/failure-alert-email.yaml
+++ b/flows/failure-alert-email.yaml
@@ -6,7 +6,7 @@ tasks:
     type: io.kestra.plugin.email.MailSend
     from: alerts@example.com
     to: team@company.com
-    username: username@example.com
+    username: "{{ secret('EMAIL_USERNAME') }}"
     password: "{{ secret('EMAIL_PASSWORD') }}"
     host: smtp.com
     port: 465
@@ -16,11 +16,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/failure-alert-gmail.yaml
+++ b/flows/failure-alert-gmail.yaml
@@ -16,11 +16,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/failure-alert-sentry-1.yaml
+++ b/flows/failure-alert-sentry-1.yaml
@@ -12,11 +12,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/failure-alert-sentry.yaml
+++ b/flows/failure-alert-sentry.yaml
@@ -12,14 +12,10 @@ tasks:
 triggers:
   - id: failed_prod_workflows
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
-      - type: io.kestra.plugin.core.condition.ExecutionNamespace
-        namespace: company
-        prefix: true
+    states:
+      - FAILED
+      - WARNING
+    when: "{{ flow.namespace | startsWith('company') }}"
 
 extend:
   shortDescription: "This flow shows how to send an alert to Sentry when a flow fails."

--- a/flows/failure-alert-slack.yaml
+++ b/flows/failure-alert-slack.yaml
@@ -10,11 +10,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/failure-alert-teams.yaml
+++ b/flows/failure-alert-teams.yaml
@@ -10,11 +10,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/failure-alert-zenduty.yaml
+++ b/flows/failure-alert-zenduty.yaml
@@ -10,11 +10,9 @@ tasks:
 triggers:
   - id: on_failure
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
+    states:
+      - FAILED
+      - WARNING
 
 extend:
   shortDescription: "This system flow will help you set up alerts for failed workflow executions. Using this pattern, you can manage alerts on failure in one place."

--- a/flows/k8s-namespace-logs-and-events.yaml
+++ b/flows/k8s-namespace-logs-and-events.yaml
@@ -33,7 +33,7 @@ tasks:
       pod_names: "{{ outputs.get_pods.metadataItems | jq('[.[].name]') }}"
 
   - id: fetch_logs_per_pod
-    type: io.kestra.plugin.core.flow.ForEach
+    type: io.kestra.plugin.core.flow.Loop
     description: Loop over pods
     values: "{{  outputs.extract_pod_names.values.pod_names | first }}"
     concurrencyLimit: 5
@@ -68,8 +68,7 @@ tasks:
           --server={{ secret('masterUrl') }}
 
 pluginDefaults:
-  - forced: true
-    type: io.kestra.plugin.scripts.shell.Commands
+  - type: io.kestra.plugin.scripts.shell.Commands
     values:
       containerImage: bitnami/kubectl
       taskRunner: # only for local testing with minikube

--- a/flows/kv-store-purge.yaml
+++ b/flows/kv-store-purge.yaml
@@ -5,7 +5,9 @@ tasks:
   - id: purge_kv
     type: io.kestra.plugin.core.kv.PurgeKV
     description: Remove key-value (KV) entries from Kestra’s internal storage every day at 12AM.
-    expiredOnly: true 
+    behavior:
+      type: key
+      expiredOnly: true # Delete only keys whose expiration date is in the past.
     namespaces:
       - system
       - company

--- a/flows/push-to-git.yaml
+++ b/flows/push-to-git.yaml
@@ -10,7 +10,7 @@ tasks:
     includeChildNamespaces: true
     gitDirectory: _flows
     url: https://github.com/kestra-io/scripts
-    username: git_username
+    username: "{{ secret('GITHUB_USERNAME') }}"
     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
     branch: kestra
     commitMessage: add flows {{ now() }}
@@ -22,7 +22,7 @@ tasks:
     files: "*"
     gitDirectory: _files
     url: https://github.com/kestra-io/scripts
-    username: git_username
+    username: "{{ secret('GITHUB_USERNAME') }}"
     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
     branch: dev
     commitMessage: add namespace files {{ now() }}

--- a/flows/sync-from-git.yaml
+++ b/flows/sync-from-git.yaml
@@ -10,7 +10,7 @@ tasks:
     delete: true
     url: https://github.com/kestra-io/flows
     branch: main
-    username: git_username
+    username: "{{ secret('GITHUB_USERNAME') }}"
     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
     dryRun: true
 
@@ -21,7 +21,7 @@ tasks:
     delete: true
     url: https://github.com/kestra-io/flows
     branch: main
-    username: git_username
+    username: "{{ secret('GITHUB_USERNAME') }}"
     password: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
     dryRun: true
 

--- a/flows/zenduty-failure-alert.yaml
+++ b/flows/zenduty-failure-alert.yaml
@@ -12,14 +12,10 @@ tasks:
 triggers:
   - id: failed_prod_workflows
     type: io.kestra.plugin.core.trigger.Flow
-    conditions:
-      - type: io.kestra.plugin.core.condition.ExecutionStatus
-        in:
-          - FAILED
-          - WARNING
-      - type: io.kestra.plugin.core.condition.ExecutionNamespace
-        namespace: company
-        prefix: true
+    states:
+      - FAILED
+      - WARNING
+    when: "{{ flow.namespace | startsWith('company') }}"
 
 extend:
   shortDescription: "This flow sends an alert to Zenduty when a production flow fails. The only required input is an integration key string value."


### PR DESCRIPTION
Fixes #246

## What

Validated all 22 `system` namespace blueprints against a **Kestra EE v2.0.0-rc1** instance and fixed every validation error. After this change, all 22 flows validate (`kestractl flows validate`) and deploy (`kestractl flows deploy`) cleanly — verified on a live 2.0.0-rc1 instance.

## Changes

| Fix | Flows |
|---|---|
| Flow trigger `conditions` → `states` | `failure-alert-discord`, `failure-alert-email`, `failure-alert-gmail`, `failure-alert-sentry-1`, `failure-alert-slack`, `failure-alert-teams`, `failure-alert-zenduty` |
| Flow trigger `conditions` (ExecutionStatus + ExecutionNamespace prefix) → `states` + `when: "{{ flow.namespace \ | startsWith('company') }}"` (canonical v2 example pattern) | `create-hubspot-ticket-on-failure`, `create-linear-issue-on-failure`, `failure-alert-sentry`, `zenduty-failure-alert` |
| Remove `forced` from `pluginDefaults` (removed in 2.0) | `copy-flows-to-new-tenant`, `k8s-namespace-logs-and-events` |
| `io.kestra.plugin.core.flow.ForEach` → `io.kestra.plugin.core.flow.Loop` | `k8s-namespace-logs-and-events` |
| `expiredOnly` → `behavior: {type: key, expiredOnly: true}` on PurgeKV | `kv-store-purge` |
| Secret-annotated properties now use `{{ secret('...') }}` instead of plain-text placeholders (fixes v2 validation warnings) | `push-to-git`, `sync-from-git`, `failure-alert-email`, `create-hubspot-ticket-on-failure`, `create-linear-issue-on-failure` |

## Remaining warnings (intentional)

The 7 unscoped failure-alert blueprints still emit *"This flow will be triggered for EVERY execution of EVERY flow on your instance"* — that is the documented purpose of those blueprints (instance-wide alerting in one place), so behavior was kept and the warning is informational.

## Validation evidence

```
22 flow(s) valid, 0 failed        # kestractl flows validate (extend block stripped)
22 flow(s) deployed successfully, 0 failed   # kestractl flows deploy --namespace system --override
```

Note: the `extend:` block is blueprint-index metadata and is rejected by the server API — it was stripped before validate/deploy, as the blueprint indexer does.

⚠️ See the note in #246 about a possible core runtime issue with the canonical `when: "{{ flow.namespace | startsWith(...) }}"` pattern on the Flow trigger.