### PR TITLE
feat: add Latchshot page capture blueprint

### DIFF
--- a/flows/capture-public-page-with-latchshot.yaml
+++ b/flows/capture-public-page-with-latchshot.yaml
@@ -1,0 +1,141 @@
+id: capture-public-page-with-latchshot
+namespace: company.team
+
+inputs:
+  - id: url
+    type: URI
+    defaults: https://example.com
+    description: Public HTTP or HTTPS page to capture. Private and credential-bearing URLs are not supported.
+
+  - id: output_format
+    type: SELECT
+    defaults: png
+    values:
+      - png
+      - jpeg
+      - pdf
+    allowCustomValue: false
+    description: Artifact format stored by Kestra.
+
+  - id: width
+    type: INT
+    defaults: 1440
+    min: 320
+    max: 2560
+    description: Browser viewport width in CSS pixels.
+
+  - id: height
+    type: INT
+    defaults: 900
+    min: 240
+    max: 1440
+    description: Browser viewport height in CSS pixels.
+
+  - id: full_page
+    type: BOOL
+    defaults: false
+    description: Capture the bounded full document height for PNG and JPEG output.
+
+  - id: delay_ms
+    type: INT
+    defaults: 0
+    min: 0
+    max: 3000
+    description: Additional delay after page readiness, in milliseconds.
+
+tasks:
+  - id: capture_page
+    type: io.kestra.plugin.core.http.Download
+    description: Render the public page with Latchshot and stream the returned image or PDF into Kestra internal storage.
+    uri: https://latchshot.fly.dev/v1/render
+    method: POST
+    contentType: application/json
+    headers:
+      Authorization: "Bearer {{ secret('LATCHSHOT_API_KEY') }}"
+    body: |
+      {
+        "url": {{ inputs.url | toJson }},
+        "format": {{ inputs.output_format | toJson }},
+        "width": {{ inputs.width }},
+        "height": {{ inputs.height }},
+        "fullPage": {{ inputs.full_page }},
+        "delay": {{ inputs.delay_ms }}
+      }
+    saveAs: "capture.{{ inputs.output_format }}"
+
+outputs:
+  - id: artifact
+    type: FILE
+    value: "{{ outputs.capture_page.uri }}"
+
+extend:
+  shortDescription: Render a public web page as a PNG, JPEG, or PDF and store the binary artifact in Kestra internal storage.
+  title: Capture a public web page as an image or PDF with Latchshot
+  metaTitle: Web Page Screenshot and PDF Workflow with Kestra and Latchshot
+  metaDescription: Render a public URL as a PNG, JPEG, or PDF with Latchshot and stream the resulting binary artifact into Kestra internal storage.
+  description: |
+    Turn a public web page into a workflow artifact without managing browser infrastructure. This blueprint sends a typed render request to Latchshot, then uses Kestra's HTTP `Download` task to stream the returned PNG, JPEG, or PDF directly into internal storage. The resulting Kestra URI can feed document delivery, visual regression, archiving, reporting, or downstream file-processing tasks.
+
+    ## How it works
+
+    1. The flow accepts a public page URL, output format, bounded viewport, full-page preference, and optional post-load delay.
+    2. `capture_page` sends those inputs to `POST https://latchshot.fly.dev/v1/render` with the `LATCHSHOT_API_KEY` secret in the bearer authorization header.
+    3. Latchshot renders the page and returns the artifact as the response body. It does not return a temporary download URL.
+    4. `io.kestra.plugin.core.http.Download` streams those response bytes into Kestra internal storage and exposes the internal URI at `{{ outputs.capture_page.uri }}`.
+    5. The flow-level `artifact` output forwards the same URI as `{{ outputs.artifact }}` for downstream tasks.
+
+    ## What you get
+
+    - PNG, JPEG, or PDF output selected at execution time.
+    - A Kestra-managed file URI instead of a third-party temporary artifact URL.
+    - Typed range validation for viewport dimensions and delay before the request runs.
+    - A reusable artifact for email, object storage, document parsing, visual comparison, or audit workflows.
+
+    ## Prerequisites
+
+    - A running Kestra instance with outbound HTTPS access.
+    - A Latchshot API key. A Free key is available from [the Latchshot key form](https://latchshot.fly.dev/?intent=kestra#trial); requesting a key does not start a paid plan.
+
+    ### Secrets
+
+    - `LATCHSHOT_API_KEY`: bearer token used only for the render API request.
+
+    ## Inputs
+
+    - `url`: public HTTP or HTTPS page URL. Latchshot rejects private, loopback, link-local, special-use, credential-bearing, and non-web-port targets.
+    - `output_format`: `png`, `jpeg`, or `pdf`; defaults to `png`.
+    - `width`: viewport width from 320 to 2560 CSS pixels; defaults to 1440.
+    - `height`: viewport height from 240 to 1440 CSS pixels; defaults to 900.
+    - `full_page`: bounded full-document capture for image formats; defaults to `false` and does not change PDF pagination.
+    - `delay_ms`: extra delay from 0 to 3000 milliseconds after page readiness; defaults to 0.
+
+    ## Outputs
+
+    - `{{ outputs.capture_page.uri }}`: the image or PDF in Kestra internal storage.
+    - `{{ outputs.capture_page.code }}`: HTTP response status.
+    - `{{ outputs.capture_page.length }}`: artifact size in bytes.
+    - `{{ outputs.artifact }}`: flow-level alias for the stored artifact URI.
+
+    ## Boundaries and data handling
+
+    Use this blueprint only for public pages you are allowed to capture. It intentionally sends no cookies, page credentials, injected scripts, or private-network addresses. Latchshot processes the target page to produce the artifact and returns the bytes directly; Kestra then retains the file according to your Kestra storage and retention configuration. Do not put secrets in the page URL. Latchshot is maintained by the blueprint contributor and is not affiliated with Kestra.
+
+    ## Quick start
+
+    1. Add `LATCHSHOT_API_KEY` to your Kestra secrets.
+    2. Import the blueprint and run it with the default `https://example.com` URL.
+    3. Open `{{ outputs.artifact }}` from the execution outputs.
+    4. Change the inputs or pass the artifact URI to a downstream task.
+
+    ## Links
+
+    - [Kestra HTTP Download task](https://kestra.io/plugins/core/http/io.kestra.plugin.core.http.download)
+    - [Latchshot API documentation](https://latchshot.fly.dev/docs.md)
+    - [Latchshot OpenAPI document](https://latchshot.fly.dev/openapi.json)
+  tags:
+    - Business
+    - Core
+  subTags:
+    - File & Data Processing Basics
+  ee: false
+  demo: false


### PR DESCRIPTION
## Summary

- add a typed blueprint that renders a public page as PNG, JPEG, or PDF through Latchshot
- stream the binary response directly into Kestra internal storage with `io.kestra.plugin.core.http.Download`
- expose the stored artifact as a flow-level `FILE` output
- document the exact secret, inputs, outputs, storage boundary, restrictions, and API links

I maintain Latchshot and am contributing this blueprint directly. Latchshot is not affiliated with Kestra.

## Safety and data boundaries

- public HTTP/HTTPS pages only; private, loopback, credential-bearing, and non-web-port targets are rejected
- no cookies, page credentials, injected scripts, or payment actions
- the response is direct binary data, not a temporary third-party URL; Kestra owns artifact retention after download
- the linked Free-key request does not start a paid plan

## Validation

- Kestra 1.3.28 native flow validation: passed with no warnings after removing only the catalog-specific `extend` block
- bounded live Kestra execution: `SUCCESS`, HTTP 200 `image/png`, 16,323 bytes, valid PNG signature, stored and downloaded from a `kestra:///` URI
- SHA-256 of the stored runtime artifact: `62dd2b7f0cb8469b892d8d6f7b1cbbbea3befc989d7e96f84ce5d956fafc9de6`
- repository tag validator equivalent: all 483 flows parsed and passed allowed-tag/count rules
- Prettier, YAML parsing, metadata/filename checks, secret scan, and `git diff --check`: passed
- the one-render `.invalid` QA credential was revoked immediately; the run is not customer or revenue evidence

## Checklist

- [x] `id` matches the hyphen-case filename and `namespace` is set
- [x] task is fully defined and described
- [x] `extend` includes title, rich description, <=160-character meta description, tags, `ee`, and `demo`
- [x] prerequisites, secret purpose, inputs, outputs, pitfalls, and links are documented
- [x] no hardcoded credential; the flow uses `secret("LATCHSHOT_API_KEY")`
