### PR TITLE
fix: repair the two blueprints whose YAML no longer deserializes

### DIFF
--- a/flows/azure-blob-backup-retention-cutover.yaml
+++ b/flows/azure-blob-backup-retention-cutover.yaml
@@ -27,10 +27,10 @@ tasks:
         endpoint: "{{ secret('AZURE_STORAGE_ENDPOINT') }}"
         from:
           container: "backups"
-          key: "{{ taskrun.value }}"
+          name: "{{ taskrun.value }}"
         to:
           container: "backups"
-          key: "archive/{{ execution.startDate | date('yyyy-MM-dd') }}/{{ taskrun.value }}"
+          name: "archive/{{ execution.startDate | date('yyyy-MM-dd') }}/{{ taskrun.value }}"
 
   - id: notify_archived
     type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook

--- a/flows/ldap-employee-offboarding-deprovision.yaml
+++ b/flows/ldap-employee-offboarding-deprovision.yaml
@@ -50,7 +50,8 @@ tasks:
   - id: apply_deprovisioning
     type: io.kestra.plugin.ldap.Modify
     description: Apply the moddn and modify operations. Each record is processed independently, so a group that no longer exists is logged and skipped without blocking the account move.
-    inputs: "{{ outputs.convert_to_ldif.urisList }}"
+    inputs:
+      - "{{ outputs.convert_to_ldif.urisList[0] }}"
 
   - id: notify
     type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook


### PR DESCRIPTION
Both of these have been serving **HTTP 500** on kestra.io. Companion docs-side fix: kestra-io/docs#5247.

## Cause

The blueprint page fetches `/blueprints/<id>/versions/latest/graph`, which parses the flow. That endpoint answers **422** for these two because their YAML no longer deserializes against the current plugin schemas:

**`azure-blob-backup-retention-cutover`**
```
Unrecognized field "key" (class io.kestra.plugin.azure.storage.blob.Copy$CopyObject),
not marked as ignorable (2 known properties: "container", "name")
```
`blob.Copy` uses `from.key` and `to.key`, but `Copy$CopyObject` only accepts `container` and `name`. Renamed both to `name`.

**`ldap-employee-offboarding-deprovision`**
```
Cannot construct instance of `java.util.ArrayList` ... from String value
('{{ outputs.convert_to_ldif.urisList }}')
(through reference chain: Flow["tasks"]->ArrayList[3]->io.kestra.plugin.ldap.Modify["inputs"])
```
`ldap.Modify.inputs` is an array but the flow passed a bare expression. Wrapped it as a list entry, matching the shape `convert_to_ldif` already uses two tasks above and the shape in the plugin's own example. `convert_to_ldif` receives a single URI, so `urisList` holds exactly one element and `[0]` addresses it explicitly — the same indexing pattern used in a dozen other flows in this repo.

## Verification

I checked every task and trigger in both flows against the live plugin definitions from `/v1/plugins/definitions`. The check **reproduces exactly the two errors the API reports** on the current files, and reports both fixed files clean:

| | result |
|---|---|
| current `azure-…` | `UNKNOWN nested 'from.key'`, `UNKNOWN nested 'to.key'` (known: container, name) |
| current `ldap-…` | `SHAPE 'inputs' is array in schema, string here` |
| fixed, both | clean |

A scan of the graph endpoint across **all 482 published blueprints** found only these two, so nothing else in the catalog is affected.

**Not verified:** runtime execution, which needs a reachable LDAP directory and an Azure storage account. These changes are schema conformance only — worth a run by someone with those before merge if you want the stronger guarantee.

## Follow-up for the plugin repo

The `io.kestra.plugin.azure.storage.blob.Copy` docs example **still shows `key:`**:

```yaml
    from:
      container: "my-bucket"
      key: "path/to/file"
```

That is almost certainly where the mistake came from. Fixing the example in the plugin source would stop this recurring in future blueprints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)