### PR TITLE
Replace Gemini examples with 3.5-flash-lite

### DIFF
--- a/flows/agent-text-summarizer.yaml
+++ b/flows/agent-text-summarizer.yaml
@@ -59,7 +59,7 @@ pluginDefaults:
     values:
       provider:
         type: io.kestra.plugin.ai.provider.GoogleGemini
-        modelName: gemini-2.5-flash
+        modelName: gemini-3.5-flash-lite
         apiKey: "{{ kv('GEMINI_API_KEY') }}"
         configuration:
           logRequests: true
@@ -80,7 +80,7 @@ extend:
     1. Three inputs drive the run: `summary_length` (a `SELECT` of short, medium, long), `language` (a `SELECT` of ISO codes en, fr, de, es, it, ru, ja), and `text` (the `STRING` content to summarize, with a default example).
     2. The `multilingual_agent` task (`io.kestra.plugin.ai.agent.AIAgent`) summarizes the input. Its `systemMessage` enforces a precise, factual tone and maps each length choice to a strict format: 1-2 sentences for short, 2-5 for medium, up to 5 paragraphs for long.
     3. The `english_brevity` task (a second `io.kestra.plugin.ai.agent.AIAgent`) chains off the first, reading `{{ outputs.multilingual_agent.textOutput }}` to produce exactly one English sentence for previews or indexing.
-    4. `pluginDefaults` wires both agents to the `io.kestra.plugin.ai.provider.GoogleGemini` provider on `gemini-2.5-flash`, with request and response logging enabled.
+    4. `pluginDefaults` wires both agents to the `io.kestra.plugin.ai.provider.GoogleGemini` provider on `gemini-3.5-flash-lite`, with request and response logging enabled.
 
     ## What you get
 
@@ -102,7 +102,7 @@ extend:
     ## Prerequisites
 
     - A Kestra instance (open source or Enterprise).
-    - A Google Gemini API key with access to `gemini-2.5-flash`.
+    - A Google Gemini API key with access to `gemini-3.5-flash-lite`.
 
     ### Secrets
 

--- a/flows/ai-agent-calling-flows.yaml
+++ b/flows/ai-agent-calling-flows.yaml
@@ -31,7 +31,7 @@ tasks:
       Return only the Execution URI with no extra characters - the structure of URL is {{ kestra.url ?? 'http://localhost:8080/'}}ui/<tenantId>/executions/<namespace>/<flowId>/<id>
     provider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
-      modelName: gemini-2.5-flash
+      modelName: gemini-3.5-flash-lite
       apiKey: "{{ secret('GEMINI_API_KEY') }}"
     tools:
       - type: io.kestra.plugin.ai.tool.KestraFlow
@@ -51,7 +51,7 @@ extend:
     ## How it works
 
     1. A `SELECT` input named `use_case` lets the user pick their orchestration goal from options such as `Business Automation`, `Data Engineering Pipeline`, and `Infrastructure Automation` (default `Just Exploring`).
-    2. The `agent` task (`io.kestra.plugin.ai.agent.AIAgent`) receives a prompt that maps each use case to a target flow id in the `tutorial` namespace, with the `io.kestra.plugin.ai.provider.GoogleGemini` provider running `gemini-2.5-flash`.
+    2. The `agent` task (`io.kestra.plugin.ai.agent.AIAgent`) receives a prompt that maps each use case to a target flow id in the `tutorial` namespace, with the `io.kestra.plugin.ai.provider.GoogleGemini` provider running `gemini-3.5-flash-lite`.
     3. The agent is granted the `io.kestra.plugin.ai.tool.KestraFlow` tool, so it can actually execute the chosen flow rather than just describe it.
     4. The `uri` task (`io.kestra.plugin.core.debug.Return`) parses the agent's `toolExecutions` output and builds a direct execution URL from the returned `tenantId`, `flowId`, and execution `id`.
 
@@ -74,7 +74,7 @@ extend:
 
     ## Prerequisites
 
-    - A Google Gemini API key with access to `gemini-2.5-flash`.
+    - A Google Gemini API key with access to `gemini-3.5-flash-lite`.
     - The target flows present in the `tutorial` namespace (for example `business-automation`, `data-engineering-pipeline`, `hello-world`).
 
     ### Secrets

--- a/flows/ai-check-weather-gemini.yaml
+++ b/flows/ai-check-weather-gemini.yaml
@@ -5,7 +5,7 @@ tasks:
   - id: ask_ai
     type: io.kestra.plugin.gemini.StructuredOutputCompletion
     apiKey: "{{ secret('GEMINI_API_KEY') }}"
-    model: "gemini-2.5-flash-preview-05-20"
+    model: "gemini-3.5-flash-lite-preview-05-20"
     prompt: "I like to go sailing when the wind is above 10 knots but below 30 knots. I sail in Cambridgeshire. If the wind is within that range, I want to know if I should go sailing or not. Also tell me the current wind speed speeds"
     jsonResponseSchema: |
       {
@@ -63,7 +63,7 @@ extend:
 
     ## How it works
 
-    1. The `ask_ai` task (`io.kestra.plugin.gemini.StructuredOutputCompletion`) sends a natural-language prompt to the `gemini-2.5-flash-preview-05-20` model. A `jsonResponseSchema` forces the answer into a fixed shape with `content` (text), `wind` (number), and `go_sailing` (boolean), so downstream tasks get machine-readable fields instead of free text.
+    1. The `ask_ai` task (`io.kestra.plugin.gemini.StructuredOutputCompletion`) sends a natural-language prompt to the `gemini-3.5-flash-lite-preview-05-20` model. A `jsonResponseSchema` forces the answer into a fixed shape with `content` (text), `wind` (number), and `go_sailing` (boolean), so downstream tasks get machine-readable fields instead of free text.
     2. The `if` task (`io.kestra.plugin.core.flow.If`) evaluates the model output by parsing `go_sailing` from the prediction with a `jq` expression, branching only when the decision is true.
     3. When the branch runs, `notify_me` (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) sends the model's `content` message to Slack.
     4. `block_calendar` (`io.kestra.plugin.googleworkspace.calendar.InsertEvent`) inserts an all-day event into a Google Calendar, embedding the live `wind` value in the event description.

--- a/flows/ai-check-weather-gemini.yaml
+++ b/flows/ai-check-weather-gemini.yaml
@@ -5,7 +5,7 @@ tasks:
   - id: ask_ai
     type: io.kestra.plugin.gemini.StructuredOutputCompletion
     apiKey: "{{ secret('GEMINI_API_KEY') }}"
-    model: "gemini-3.5-flash-lite-preview-05-20"
+    model: "gemini-3.5-flash-lite"
     prompt: "I like to go sailing when the wind is above 10 knots but below 30 knots. I sail in Cambridgeshire. If the wind is within that range, I want to know if I should go sailing or not. Also tell me the current wind speed speeds"
     jsonResponseSchema: |
       {
@@ -63,7 +63,7 @@ extend:
 
     ## How it works
 
-    1. The `ask_ai` task (`io.kestra.plugin.gemini.StructuredOutputCompletion`) sends a natural-language prompt to the `gemini-3.5-flash-lite-preview-05-20` model. A `jsonResponseSchema` forces the answer into a fixed shape with `content` (text), `wind` (number), and `go_sailing` (boolean), so downstream tasks get machine-readable fields instead of free text.
+    1. The `ask_ai` task (`io.kestra.plugin.gemini.StructuredOutputCompletion`) sends a natural-language prompt to the `gemini-3.5-flash-lite` model. A `jsonResponseSchema` forces the answer into a fixed shape with `content` (text), `wind` (number), and `go_sailing` (boolean), so downstream tasks get machine-readable fields instead of free text.
     2. The `if` task (`io.kestra.plugin.core.flow.If`) evaluates the model output by parsing `go_sailing` from the prediction with a `jq` expression, branching only when the decision is true.
     3. When the branch runs, `notify_me` (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) sends the model's `content` message to Slack.
     4. `block_calendar` (`io.kestra.plugin.googleworkspace.calendar.InsertEvent`) inserts an all-day event into a Google Calendar, embedding the live `wind` value in the event description.

--- a/flows/ai-github-daily-healthcheck.yaml
+++ b/flows/ai-github-daily-healthcheck.yaml
@@ -178,7 +178,7 @@ pluginDefaults:
     values:
       provider:
         type: io.kestra.plugin.ai.provider.GoogleGemini
-        modelName: gemini-2.5-flash
+        modelName: gemini-3.5-flash-lite
         apiKey: "{{ secret('GEMINI_API_KEY') }}"
       allowFailure: true
       configuration:
@@ -213,7 +213,7 @@ extend:
     2. The `run_parallel` task (`io.kestra.plugin.core.flow.Parallel`) fires three `io.kestra.plugin.core.http.Request` calls at once: recent issues, pull requests, and Actions workflow runs for `inputs.github_repo`. Each request retries exponentially up to 3 attempts and is allowed to fail without killing the run.
     3. The `concatenate_data` task (`io.kestra.plugin.core.storage.Write`) merges the three response bodies into one JSON document in internal storage, defaulting any failed call to an empty array.
     4. The `filter_prep_metrics` task (`io.kestra.plugin.scripts.python.Script`) loads that file, keeps only items created or updated within `inputs.window_hours`, projects noisy API objects down to useful fields, and emits five KPI lists via `Kestra.outputs`.
-    5. The `ai_day_brief` task (`io.kestra.plugin.ai.agent.AIAgent`) prompts `gemini-2.5-flash` to write a markdown summary limited to the most pressing items, always citing issue and PR ids, followed by a proposed plan of attack.
+    5. The `ai_day_brief` task (`io.kestra.plugin.ai.agent.AIAgent`) prompts `gemini-3.5-flash-lite` to write a markdown summary limited to the most pressing items, always citing issue and PR ids, followed by a proposed plan of attack.
     6. `log_output` records the brief and `post_to_slack` (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) delivers it. An `errors` branch alerts Slack on any failure, and a `MAX_DURATION` SLA cancels runs exceeding 10 minutes.
 
     ## What you get

--- a/flows/ai-incident-triage-rag.yaml
+++ b/flows/ai-incident-triage-rag.yaml
@@ -58,7 +58,7 @@ tasks:
     description: Ask the model for triage steps grounded in the knowledge base.
     chatProvider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
-      modelName: gemini-2.5-flash
+      modelName: gemini-3.5-flash-lite
     embeddingProvider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
       modelName: gemini-embedding-001
@@ -113,7 +113,7 @@ extend:
     1. The `incident_trigger` (`io.kestra.plugin.core.trigger.Webhook`) accepts a POST from monitoring or ITSM tooling, secured by `INCIDENT_WEBHOOK_KEY`. A JSON `incident` input provides a fallback payload so the flow also runs manually.
     2. The `log_incident` task (`io.kestra.plugin.core.log.Log`) records the raw payload.
     3. The `ingest_kb` task (`io.kestra.plugin.ai.rag.IngestDocument`) embeds an inline knowledge base stub with the `gemini-embedding-001` model into `io.kestra.plugin.ai.embeddings.KestraKVStore`, dropping the previous index each run so the store always mirrors the current playbook.
-    4. The `enrich_with_rag` task (`io.kestra.plugin.ai.rag.ChatCompletion`) retrieves relevant KB segments and asks `gemini-2.5-flash` for a concise summary, work notes, and a proposed resolution, constrained by a system message that enforces Risk, Steps, and Verification sections.
+    4. The `enrich_with_rag` task (`io.kestra.plugin.ai.rag.ChatCompletion`) retrieves relevant KB segments and asks `gemini-3.5-flash-lite` for a concise summary, work notes, and a proposed resolution, constrained by a system message that enforces Risk, Steps, and Verification sections.
     5. `log_incident_response` persists the answer in execution logs and `post_to_slack` (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) delivers it to the on-call channel.
 
     ## What you get

--- a/flows/ai-jira-itops-triage.yaml
+++ b/flows/ai-jira-itops-triage.yaml
@@ -75,7 +75,7 @@ tasks:
     description: Ask the model for triage steps grounded in the playbook.
     chatProvider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
-      modelName: gemini-2.5-flash
+      modelName: gemini-3.5-flash-lite
     embeddingProvider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
       modelName: gemini-embedding-001
@@ -146,7 +146,7 @@ extend:
     1. The `jira_issue` trigger (`io.kestra.plugin.core.trigger.Webhook`) receives the issue-created payload from a Jira automation rule, secured by `JIRA_WEBHOOK_KEY`.
     2. The `log_issue` task (`io.kestra.plugin.core.debug.Return`) uses a `jq` expression to project the payload down to id, key, summary, description, reporter, and priority.
     3. The `ingest_kb` task (`io.kestra.plugin.ai.rag.IngestDocument`) splits the inline playbook stub by paragraph (1024 char segments, 512 overlap) and embeds it with `gemini-embedding-001` into `io.kestra.plugin.ai.embeddings.KestraKVStore`.
-    4. The `invoke_ai` task (`io.kestra.plugin.ai.rag.ChatCompletion`) retrieves matching playbook segments and asks `gemini-2.5-flash` for a concise summary, work notes, and a proposed resolution with mandatory Risk, Steps, and Verification sections.
+    4. The `invoke_ai` task (`io.kestra.plugin.ai.rag.ChatCompletion`) retrieves matching playbook segments and asks `gemini-3.5-flash-lite` for a concise summary, work notes, and a proposed resolution with mandatory Risk, Steps, and Verification sections.
     5. The `update_comment` task (`io.kestra.plugin.core.http.Request`) POSTs the answer to the Jira REST API v3 comment endpoint as an Atlassian Document Format body, authenticated with basic auth built from `JIRA_EMAIL` and `JIRA_API_TOKEN`.
 
     ## What you get

--- a/flows/ai-model-router.yaml
+++ b/flows/ai-model-router.yaml
@@ -55,7 +55,7 @@ tasks:
         - id: reasoning_model
           type: io.kestra.plugin.gemini.ChatCompletion
           apiKey: "{{ secret('GEMINI_API_KEY') }}"
-          model: gemini-2.5-flash
+          model: gemini-3.5-flash-lite
           messages:
             - role: user
               content: "{{ inputs.question }}"

--- a/flows/ai-model-router.yaml
+++ b/flows/ai-model-router.yaml
@@ -95,7 +95,7 @@ extend:
 
     1. The `classify_request` task (`io.kestra.plugin.openai.ChatCompletion`, model `gpt-4o-mini`) classifies the user prompt into one of four categories using a constrained `jsonResponseSchema` and a small `maxTokens` budget, keeping classification fast and cheap.
     2. The `route_to_model` task (`io.kestra.plugin.core.flow.Switch`) reads the category with a `jq` expression over the classifier output and selects a branch.
-    3. Coding prompts go to `coding_model` (`io.kestra.plugin.anthropic.ChatCompletion`, Claude Opus). Reasoning prompts go to `reasoning_model` (`io.kestra.plugin.gemini.ChatCompletion`, Gemini 2.5 Flash). Search prompts go to `search_model` (`io.kestra.plugin.perplexity.ChatCompletion`, Sonar) for real-time web retrieval.
+    3. Coding prompts go to `coding_model` (`io.kestra.plugin.anthropic.ChatCompletion`, Claude Opus). Reasoning prompts go to `reasoning_model` (`io.kestra.plugin.gemini.ChatCompletion`, Gemini 3.5 Flash Lite). Search prompts go to `search_model` (`io.kestra.plugin.perplexity.ChatCompletion`, Sonar) for real-time web retrieval.
     4. Anything else falls through to the Switch `defaults`, hitting `general_model` (`io.kestra.plugin.openai.ChatCompletion`, `gpt-4o-mini`) for cost-efficient general answers.
 
     ## What you get

--- a/flows/ai-plan-my-day.yaml
+++ b/flows/ai-plan-my-day.yaml
@@ -111,7 +111,7 @@ pluginDefaults:
     values:
       provider:
         type: io.kestra.plugin.ai.provider.GoogleGemini
-        modelName: gemini-2.5-flash
+        modelName: gemini-3.5-flash-lite
         apiKey: "{{ secret('GEMINI_API_KEY') }}"
       allowFailure: true
       configuration:
@@ -144,7 +144,7 @@ extend:
     1. The `incoming_webhook` trigger (`io.kestra.plugin.core.trigger.Webhook`) lets any HTTP caller request a plan on demand, secured by `PLAN_MY_DAY_WEBHOOK_KEY`. The flow also runs manually with the `city` input, defaulting to Austin.
     2. The `geocode_city` task (`io.kestra.plugin.core.http.Request`) resolves the city name, and `parse_geo` (`io.kestra.plugin.scripts.python.Script`) extracts latitude and longitude, failing fast with a clear error when the city is unknown.
     3. The `parallel_tasks` task (`io.kestra.plugin.core.flow.Parallel`) calls `weather_api` and `air_quality_api` concurrently. Both requests inherit retry and header policy from `pluginDefaults` and are allowed to fail individually.
-    4. The `day_brief` task (`io.kestra.plugin.ai.agent.AIAgent`) prompts `gemini-2.5-flash` with both response bodies, substituting "not available!" for any missing data so the agent still produces a useful plan on partial failures.
+    4. The `day_brief` task (`io.kestra.plugin.ai.agent.AIAgent`) prompts `gemini-3.5-flash-lite` with both response bodies, substituting "not available!" for any missing data so the agent still produces a useful plan on partial failures.
     5. `log_output` records the answer, the flow exposes it as the `brief` output, the `errors` branch posts to Slack on failure, and a `MAX_DURATION` SLA cancels runs over 10 minutes.
 
     ## What you get

--- a/flows/ai-product-recommender.yaml
+++ b/flows/ai-product-recommender.yaml
@@ -51,7 +51,7 @@ tasks:
     provider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
       apiKey: "{{ secret('GEMINI_API_KEY') }}"
-      modelName: "gemini-2.5-flash"
+      modelName: "gemini-3.5-flash-lite"
     configuration:
       responseFormat:
         type: JSON
@@ -102,7 +102,7 @@ extend:
     ## How it works
     1. The `category` input (`SELECT`) populates its options at execution time with the Pebble `http()` function against the DummyJSON categories endpoint. The `product` input uses `dependsOn` to re-query options whenever the category changes.
     2. The `get_all_products` task (`io.kestra.plugin.core.http.Request`) downloads the full product list for the chosen category, with `allowFailed` so a bad category does not hard-stop the run.
-    3. The `recommend_product` task (`io.kestra.plugin.ai.agent.AIAgent`) sends the product JSON to `gemini-2.5-flash` with weighing criteria in the prompt. `responseFormat: JSON` plus a `jsonSchema` with required fields guarantees a machine-readable answer, and `taskCache` returns the cached recommendation when inputs have not changed.
+    3. The `recommend_product` task (`io.kestra.plugin.ai.agent.AIAgent`) sends the product JSON to `gemini-3.5-flash-lite` with weighing criteria in the prompt. `responseFormat: JSON` plus a `jsonSchema` with required fields guarantees a machine-readable answer, and `taskCache` returns the cached recommendation when inputs have not changed.
     4. The `store_recommendation_in_kv` task (`io.kestra.plugin.core.kv.Set`) persists the structured answer under the execution id with `kvType: JSON`.
     5. The `get_recommended_product_details` task calls the products endpoint with `outputs.recommend_product.jsonOutput.id`, proving the structured output is directly usable in downstream expressions.
     6. The `log_recommendation` task (`io.kestra.plugin.core.log.Log`) prints a human-readable summary ready to forward to Slack or email.

--- a/flows/ai-servicenow-incident-triage.yaml
+++ b/flows/ai-servicenow-incident-triage.yaml
@@ -51,7 +51,7 @@ tasks:
     description: Ask the model for triage steps grounded in the knowledge base.
     chatProvider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
-      modelName: gemini-2.5-flash
+      modelName: gemini-3.5-flash-lite
     embeddingProvider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
       modelName: gemini-embedding-001
@@ -120,7 +120,7 @@ extend:
     2. The `get_incidents` task (`io.kestra.plugin.servicenow.Get`) queries the `incident` table using credentials supplied once via `pluginDefaults`.
     3. The `last_incident` task (`io.kestra.plugin.core.debug.Return`) sorts by incident number with `jq` and keeps only `sys_id`, `number`, `priority`, and the descriptions.
     4. The `build_kb_rag` task (`io.kestra.plugin.ai.rag.IngestDocument`) embeds the inline playbook stub with `gemini-embedding-001` into `io.kestra.plugin.ai.embeddings.KestraKVStore`, dropping the old index each run.
-    5. The `ask_ai` task (`io.kestra.plugin.ai.rag.ChatCompletion`) retrieves matching playbook sections and asks `gemini-2.5-flash` for a summary, work notes, and proposed resolution with mandatory Risk, Steps, and Verification sections.
+    5. The `ask_ai` task (`io.kestra.plugin.ai.rag.ChatCompletion`) retrieves matching playbook sections and asks `gemini-3.5-flash-lite` for a summary, work notes, and proposed resolution with mandatory Risk, Steps, and Verification sections.
     6. The `if_suggestion` task (`io.kestra.plugin.core.flow.If`) checks the answer is not 'N/A', and only then `update_servicenow` (`io.kestra.plugin.servicenow.Update`) patches the incident's `comments` field by `sys_id`.
 
     ## What you get

--- a/flows/ai-starship-recommender.yaml
+++ b/flows/ai-starship-recommender.yaml
@@ -61,7 +61,7 @@ tasks:
     provider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
       apiKey: "{{ secret('GEMINI_API_KEY') }}"
-      modelName: "gemini-2.5-flash"
+      modelName: "gemini-3.5-flash-lite"
     configuration:
       responseFormat:
         type: JSON

--- a/flows/asset-upgrade-servers.yaml
+++ b/flows/asset-upgrade-servers.yaml
@@ -79,7 +79,7 @@ errors:
     type: io.kestra.plugin.ai.agent.AIAgent
     provider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
-      modelName: gemini-2.5-flash
+      modelName: gemini-3.5-flash-lite
       apiKey: "{{ secret('GEMINI_API_KEY') }}"
     systemMessage: |
       You are a support engineer with expertise in Infra Automation and Kestra orchestration.

--- a/flows/asset-upgrade-servers.yaml
+++ b/flows/asset-upgrade-servers.yaml
@@ -116,7 +116,7 @@ extend:
     3. `run_upgrades` (`io.kestra.plugin.core.flow.ForEach`) iterates over the matches. `get_server_details` (`io.kestra.plugin.core.execution.SetVariables`) unpacks id, IP, and current version.
     4. `ssh_python_update` (`io.kestra.plugin.scripts.shell.Commands`) simulates the upgrade over SSH. Crucially, its `assets` block declares the server as input and re-registers it as output with `python_version` set to the target, so the catalog reflects reality the moment the upgrade lands.
     5. `export_assets_to_file` (`io.kestra.plugin.ee.assets.AssetShipper` with `io.kestra.plugin.ee.assets.FileAssetExporter`) exports the catalog as JSON for CMDBs or reporting.
-    6. On any failure, the `errors` branch runs `analyze_error` (`io.kestra.plugin.ai.agent.AIAgent` with `io.kestra.plugin.ai.provider.GoogleGemini`), feeding `{{ errorLogs() }}` to Gemini 2.5 Flash and logging the diagnosis.
+    6. On any failure, the `errors` branch runs `analyze_error` (`io.kestra.plugin.ai.agent.AIAgent` with `io.kestra.plugin.ai.provider.GoogleGemini`), feeding `{{ errorLogs() }}` to Gemini 3.5 Flash Lite and logging the diagnosis.
 
     ## What you get
     - Metadata-driven targeting: only outdated machines in the chosen env are touched.

--- a/flows/gemini-batch-review-moderation.yaml
+++ b/flows/gemini-batch-review-moderation.yaml
@@ -15,7 +15,7 @@ tasks:
       - id: classify_review
         type: io.kestra.plugin.gemini.StructuredOutputCompletion
         apiKey: "{{ secret('GEMINI_API_KEY') }}"
-        model: "gemini-2.5-flash-lite"
+        model: "gemini-3.5-flash-lite-lite"
         prompt: "Moderate this customer review for toxicity, spam, and policy violations. Review: {{ taskrun.value.text }}"
         jsonResponseSchema: |
           {
@@ -59,7 +59,7 @@ extend:
 
     1. `fetch_pending_reviews` (`io.kestra.plugin.core.http.Request`) pulls up to 200 pending reviews from the moderation queue API.
     2. `moderate` (`io.kestra.plugin.core.flow.ForEach`) iterates the returned reviews with `concurrencyLimit: 5`, so at most five reviews are classified at once regardless of queue size.
-    3. Inside each iteration, `classify_review` (`io.kestra.plugin.gemini.StructuredOutputCompletion`) asks `gemini-2.5-flash-lite` for a verdict (`approve`, `flag`, or `reject`) plus a reason, constrained by a `jsonResponseSchema`.
+    3. Inside each iteration, `classify_review` (`io.kestra.plugin.gemini.StructuredOutputCompletion`) asks `gemini-3.5-flash-lite-lite` for a verdict (`approve`, `flag`, or `reject`) plus a reason, constrained by a `jsonResponseSchema`.
     4. `write_back` (`io.kestra.plugin.core.http.Request`) posts the verdict to the review's own record in the source system, so the queue does not re-offer already-moderated items on the next run.
     5. `notify_batch_complete` (`io.kestra.plugin.discord.DiscordIncomingWebhook`) posts one message when the whole batch finishes.
     6. A disabled `nightly_moderation` Schedule trigger (`io.kestra.plugin.core.trigger.Schedule`) shows the cron pattern for running the batch unattended every night.

--- a/flows/gemini-batch-review-moderation.yaml
+++ b/flows/gemini-batch-review-moderation.yaml
@@ -15,7 +15,7 @@ tasks:
       - id: classify_review
         type: io.kestra.plugin.gemini.StructuredOutputCompletion
         apiKey: "{{ secret('GEMINI_API_KEY') }}"
-        model: "gemini-3.5-flash-lite-lite"
+        model: "gemini-3.5-flash-lite"
         prompt: "Moderate this customer review for toxicity, spam, and policy violations. Review: {{ taskrun.value.text }}"
         jsonResponseSchema: |
           {
@@ -59,7 +59,7 @@ extend:
 
     1. `fetch_pending_reviews` (`io.kestra.plugin.core.http.Request`) pulls up to 200 pending reviews from the moderation queue API.
     2. `moderate` (`io.kestra.plugin.core.flow.ForEach`) iterates the returned reviews with `concurrencyLimit: 5`, so at most five reviews are classified at once regardless of queue size.
-    3. Inside each iteration, `classify_review` (`io.kestra.plugin.gemini.StructuredOutputCompletion`) asks `gemini-3.5-flash-lite-lite` for a verdict (`approve`, `flag`, or `reject`) plus a reason, constrained by a `jsonResponseSchema`.
+    3. Inside each iteration, `classify_review` (`io.kestra.plugin.gemini.StructuredOutputCompletion`) asks `gemini-3.5-flash-lite` for a verdict (`approve`, `flag`, or `reject`) plus a reason, constrained by a `jsonResponseSchema`.
     4. `write_back` (`io.kestra.plugin.core.http.Request`) posts the verdict to the review's own record in the source system, so the queue does not re-offer already-moderated items on the next run.
     5. `notify_batch_complete` (`io.kestra.plugin.discord.DiscordIncomingWebhook`) posts one message when the whole batch finishes.
     6. A disabled `nightly_moderation` Schedule trigger (`io.kestra.plugin.core.trigger.Schedule`) shows the cron pattern for running the batch unattended every night.

--- a/flows/gemini-model-fallback-resilience.yaml
+++ b/flows/gemini-model-fallback-resilience.yaml
@@ -36,7 +36,7 @@ tasks:
   - id: classify_fallback_2
     type: io.kestra.plugin.gemini.ChatCompletion
     apiKey: "{{ secret('GEMINI_API_KEY') }}"
-    model: "gemini-2.5-pro"
+    model: "gemini-3.5-flash-lite"
     allowFailure: true
     runIf: "{{ outputs.classify_request.predictions is not defined and outputs.classify_fallback_1.predictions is not defined }}"
     messages:
@@ -68,7 +68,7 @@ extend:
     1. The `on_request` trigger (`io.kestra.plugin.core.trigger.Webhook`) starts one execution per inbound request, exposing the payload as `trigger.body`.
     2. `classify_request` (`io.kestra.plugin.gemini.ChatCompletion`) calls `gemini-3.1-pro-preview` first, with a `retry` policy of 5 attempts on a 1-second constant interval and `allowFailure: true` so a persistent failure does not kill the execution outright.
     3. `classify_fallback_1` calls `gemini-3-pro-preview`, gated by `runIf` so it only runs when the first call produced no prediction.
-    4. `classify_fallback_2` calls `gemini-2.5-pro`, gated by a `runIf` that checks both prior tasks failed to produce a prediction.
+    4. `classify_fallback_2` calls `gemini-3.5-flash-lite`, gated by a `runIf` that checks both prior tasks failed to produce a prediction.
     5. `notify_if_fallback_used` (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) fires only when a fallback task actually ran, giving the team visibility into outage cadence without paging on every retry.
     6. A flow-level `concurrency` block (`behavior: QUEUE`, `limit: 10`) caps simultaneous executions so a burst of inbound requests cannot exhaust the Gemini quota or hammer the fallback chain in parallel.
 

--- a/flows/gemini-multimodal-receipt-extraction.yaml
+++ b/flows/gemini-multimodal-receipt-extraction.yaml
@@ -5,7 +5,7 @@ tasks:
   - id: describe_receipt
     type: io.kestra.plugin.gemini.MultimodalCompletion
     apiKey: "{{ secret('GEMINI_API_KEY') }}"
-    model: "gemini-2.5-flash"
+    model: "gemini-3.5-flash-lite"
     contents:
       - content: "List the vendor name, purchase date, currency, and total amount printed on this receipt as plain labeled text."
       - mimeType: "image/jpeg"
@@ -14,7 +14,7 @@ tasks:
   - id: structure_fields
     type: io.kestra.plugin.gemini.StructuredOutputCompletion
     apiKey: "{{ secret('GEMINI_API_KEY') }}"
-    model: "gemini-2.5-flash-lite"
+    model: "gemini-3.5-flash-lite-lite"
     prompt: "Reformat this receipt description into the required fields. Description: {{ outputs.describe_receipt.text }}"
     jsonResponseSchema: |
       {
@@ -58,7 +58,7 @@ extend:
     ## How it works
 
     1. The `new_receipt` trigger (`io.kestra.plugin.aws.s3.Trigger`) polls the `expense-receipts` bucket's `inbox/` prefix every 5 minutes and starts one execution per batch of new images, downloading matches to internal storage.
-    2. `describe_receipt` (`io.kestra.plugin.gemini.MultimodalCompletion`) sends the downloaded image alongside a text prompt to `gemini-2.5-flash`, asking for the vendor, purchase date, currency, and total as labeled plain text.
+    2. `describe_receipt` (`io.kestra.plugin.gemini.MultimodalCompletion`) sends the downloaded image alongside a text prompt to `gemini-3.5-flash-lite`, asking for the vendor, purchase date, currency, and total as labeled plain text.
     3. `structure_fields` (`io.kestra.plugin.gemini.StructuredOutputCompletion`) takes that free-text description and reshapes it into a fixed JSON schema (`vendor`, `purchaseDate`, `currency`, `total`), so downstream systems get typed fields instead of prose.
     4. `notify_finance` (`io.kestra.plugin.googleworkspace.chat.GoogleChatIncomingWebhook`) posts the structured result to a Google Chat space for the finance team to review.
 

--- a/flows/gemini-multimodal-receipt-extraction.yaml
+++ b/flows/gemini-multimodal-receipt-extraction.yaml
@@ -14,7 +14,7 @@ tasks:
   - id: structure_fields
     type: io.kestra.plugin.gemini.StructuredOutputCompletion
     apiKey: "{{ secret('GEMINI_API_KEY') }}"
-    model: "gemini-3.5-flash-lite-lite"
+    model: "gemini-3.5-flash-lite"
     prompt: "Reformat this receipt description into the required fields. Description: {{ outputs.describe_receipt.text }}"
     jsonResponseSchema: |
       {

--- a/flows/k8s-ai-incident-monitor.yaml
+++ b/flows/k8s-ai-incident-monitor.yaml
@@ -65,7 +65,7 @@ tasks:
     provider:
       type: io.kestra.plugin.ai.provider.GoogleGemini
       apiKey: "{{ secret('GOOGLE_API_KEY') }}"
-      modelName: gemini-2.5-flash
+      modelName: gemini-3.5-flash-lite
     messages:
       - type: SYSTEM
         content: |
@@ -140,7 +140,7 @@ extend:
 
     ## How it works
     1. A `io.kestra.plugin.core.flow.Parallel` task fans out seven `io.kestra.plugin.kubernetes.kubectl.Get` calls at once to collect `pods`, `events`, `nodes`, `deployments`, `services`, `resourcequotas`, and selected `kube-system` pod logs, each written to its own output file.
-    2. `io.kestra.plugin.ai.completion.ChatCompletion` sends the collected data to Google Gemini (`gemini-2.5-flash`) acting as an SRE, returning a health summary, root cause analysis, impact assessment, and remediation commands.
+    2. `io.kestra.plugin.ai.completion.ChatCompletion` sends the collected data to Google Gemini (`gemini-3.5-flash-lite`) acting as an SRE, returning a health summary, root cause analysis, impact assessment, and remediation commands.
     3. A `io.kestra.plugin.scripts.python.Script` task (`classify_severity`) scans the AI response for keywords and labels the incident `LOW`, `MEDIUM`, or `HIGH`.
     4. `io.kestra.plugin.slack.notifications.SlackIncomingWebhook` fires only when `runIf` evaluates severity as `HIGH`, posting the full analysis to your channel.
     5. A `io.kestra.plugin.core.trigger.Schedule` trigger runs the whole pipeline on a `*/5 * * * *` cron.

--- a/flows/vertex-ai-batch-row-enrichment.yaml
+++ b/flows/vertex-ai-batch-row-enrichment.yaml
@@ -28,7 +28,7 @@ tasks:
         type: io.kestra.plugin.gcp.vertexai.ChatCompletion
         description: Ask Gemini on Vertex AI for a one-word sentiment.
         region: us-central1
-        modelId: gemini-1.5-flash
+        modelId: gemini-3.5-flash-lite
         messages:
           - author: user
             content: "Reply with exactly one word, positive or negative, for this review: {{ taskrun.value.review }}"
@@ -91,7 +91,7 @@ extend:
     1. A `io.kestra.plugin.core.trigger.Schedule` trigger (`nightly`, cron `0 2 * * *`, disabled by default) launches the batch on a cadence you control.
     2. `select_rows` runs `io.kestra.plugin.gcp.bigquery.Query` with `fetchType: FETCH` to pull rows from `analytics.reviews` where `sentiment IS NULL`, limited to 50.
     3. `enrich` is a `io.kestra.plugin.core.flow.ForEach` over `outputs.select_rows.rows` with `concurrencyLimit: 4`, capping parallel calls to Vertex AI.
-    4. Inside the loop, `classify` calls `io.kestra.plugin.gcp.vertexai.ChatCompletion` with `region: us-central1` and `modelId: gemini-1.5-flash`, asking Gemini for a one-word sentiment.
+    4. Inside the loop, `classify` calls `io.kestra.plugin.gcp.vertexai.ChatCompletion` with `region: us-central1` and `modelId: gemini-3.5-flash-lite`, asking Gemini for a one-word sentiment.
     5. `store` runs another `io.kestra.plugin.gcp.bigquery.Query` that updates the row with `outputs.classify.predictions[0]`.
     6. `notify` sends an `io.kestra.plugin.email.MailSend` summary with the batch size and execution id.
     7. An `errors` handler (`alert_on_failure`) emails the team if any step fails.
@@ -115,7 +115,7 @@ extend:
     ## Prerequisites
     - A GCP project with BigQuery and the Vertex AI API enabled.
     - A reviews table (`analytics.reviews`) with `id`, `review`, and a nullable `sentiment` column.
-    - A Gemini model available in your chosen region (default `us-central1`, `gemini-1.5-flash`).
+    - A Gemini model available in your chosen region (default `us-central1`, `gemini-3.5-flash-lite`).
     - SMTP credentials for the notification emails.
 
     ### Secrets

--- a/flows/vertex-ai-event-classification-guardrail.yaml
+++ b/flows/vertex-ai-event-classification-guardrail.yaml
@@ -12,7 +12,7 @@ tasks:
     type: io.kestra.plugin.gcp.vertexai.ChatCompletion
     description: Ask Gemini to label the event priority.
     region: us-central1
-    modelId: gemini-1.5-flash
+    modelId: gemini-3.5-flash-lite
     messages:
       - author: user
         content: "Classify this event as one word, high or low priority: {{ trigger.data }}"
@@ -76,7 +76,7 @@ extend:
     ## How it works
 
     1. The `io.kestra.plugin.gcp.pubsub.RealtimeTrigger` (`on_event`) subscribes to the `events` topic via the `kestra-events-sub` subscription and starts one execution per message, deserializing the payload as JSON.
-    2. `io.kestra.plugin.gcp.vertexai.ChatCompletion` (`classify`) sends the event body to `gemini-1.5-flash` in `us-central1` with a tight prompt that forces a single-word label, `high` or `low`.
+    2. `io.kestra.plugin.gcp.vertexai.ChatCompletion` (`classify`) sends the event body to `gemini-3.5-flash-lite` in `us-central1` with a tight prompt that forces a single-word label, `high` or `low`.
     3. `io.kestra.plugin.core.flow.If` (`guardrail`) evaluates `outputs.classify.predictions[0] | lower == 'high'` and only enters the then-branch when the model returns high priority.
     4. `io.kestra.plugin.gcp.bigquery.Query` (`record`) inserts the message id, priority, and timestamp into the `analytics.priority_events` audit table.
     5. `io.kestra.plugin.discord.DiscordIncomingWebhook` (`escalate`) posts a structured alert to the configured Discord channel with the message id and the execution id.
@@ -106,7 +106,7 @@ extend:
     - A Pub/Sub topic named `events` and a subscription named `kestra-events-sub`.
     - A BigQuery dataset `analytics` with a `priority_events` table (`message_id STRING, priority STRING, logged_at TIMESTAMP`).
     - A Discord channel with an incoming webhook configured.
-    - Gemini (`gemini-1.5-flash`) enabled in the `us-central1` region.
+    - Gemini (`gemini-3.5-flash-lite`) enabled in the `us-central1` region.
 
     ### Secrets
 
@@ -125,7 +125,7 @@ extend:
     ## How to extend
 
     - Add more labels (urgent, spam, sensitive) and expand the If into a Switch task for per-label routing.
-    - Swap `gemini-1.5-flash` for `gemini-1.5-pro` when accuracy matters more than latency.
+    - Swap `gemini-3.5-flash-lite` for a Gemini Pro model when accuracy matters more than latency.
     - Replace the BigQuery insert with a streaming write to a different table, or fan out to Kafka or Cloud Storage.
     - Add a second classification pass for low-priority events that look suspicious, using a stricter prompt.
     - Wire the escalation step to PagerDuty, Slack, or ServiceNow instead of (or alongside) Discord.


### PR DESCRIPTION
Gemini 2.5 Flash is being [shutdown in October](https://ai.google.dev/gemini-api/docs/deprecations). 3.5 Flash-Lite is the closest replacement regarding cost.

Replacing all examples