### PR TITLE
fix: require manual vacation approval

### DIFF
--- a/flows/business-processes.yaml
+++ b/flows/business-processes.yaml
@@ -30,7 +30,14 @@ tasks:
   - id: wait_for_approval
     type: io.kestra.plugin.core.flow.Pause
     description: Pause the flow while waiting for manual approval.
-    pauseDuration: PT30S
+    onResume:
+      - id: approved
+        type: BOOL
+        description: Whether to approve the vacation request.
+        defaults: true
+      - id: reason
+        type: STRING
+        description: Reason for approving or rejecting the vacation request.
 
   - id: process_request
     type: io.kestra.plugin.core.http.Request
@@ -59,7 +66,7 @@ extend:
     ## How it works
     1. The flow collects request details through `inputs`: an employee `request.name`, a `request.start_date`, a `request.end_date`, and a `slack_webhook_uri`. Kestra renders these as a form automatically in the UI.
     2. The `send_approval_request` task (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) posts a message to Slack with a link back to the execution so an approver can act.
-    3. The `wait_for_approval` task (`io.kestra.plugin.core.flow.Pause`) pauses the execution with a `pauseDuration` of `PT30S`, holding the flow until a human clicks `Resume` in the Kestra UI.
+    3. The `wait_for_approval` task (`io.kestra.plugin.core.flow.Pause`) pauses the execution until a human provides an approval decision and reason, then clicks `Resume` in the Kestra UI.
     4. Once resumed, the `process_request` task (`io.kestra.plugin.core.http.Request`) sends a `POST` with `contentType` `application/json` and the approved `request` payload to the target API.
 
     ## What you get
@@ -93,7 +100,7 @@ extend:
 
     ## How to extend
     - Replace the mock URI in `process_request` with your HR or HTTP backend.
-    - Increase `pauseDuration` or remove it so the flow waits indefinitely for approval.
+    - Add a timeout policy if approval must happen within a fixed period.
     - Add a `Switch` task to branch on approve versus reject responses.
     - Add a `Schedule` or webhook trigger to start the process automatically.
     - Send a confirmation Slack message after submission.


### PR DESCRIPTION
## What changed

- I replaced the automatic 30-second pause in the business processes tutorial with explicit `onResume` inputs.
- I added fields for the approval decision and reason.
- I also updated the tutorial text to describe the manual resume step.
- I updated the extension guidance to suggest adding a timeout policy when needed.

## Why

The previous `pauseDuration: PT30S` automatically resumed the workflow after 30 seconds, so the tutorial didn't demonstrate a real human approval gate.

The change I've proposed here keeps the execution paused until someone explicitly resumes it with an approval decision.

Fixes kestra-io/kestra#18680

## Validation

- Parsed `flows/business-processes.yaml` successfully with `js-yaml`.
- Ran `git diff --check`.
