### PR TITLE
Cloud Getting Started example blueprints: ELT, automation, AI enrichmen

### DIFF
--- a/flows/getting-started-ai-enrichment.yaml
+++ b/flows/getting-started-ai-enrichment.yaml
@@ -1,0 +1,141 @@
+id: getting-started-ai-enrichment
+namespace: tutorial
+
+description: |
+  # AI enrichment example
+  Fetches a small public dataset and logs a preview. Customize it to use your own LLM (OpenAI by default, or swap in Anthropic or Google Gemini) to summarize and classify the data.
+
+  Descriptions support **Markdown**.
+
+labels:
+  name: "Example: AI Enrichment"
+
+tasks:
+  - id: extract
+    type: io.kestra.plugin.core.http.Request
+    description: Fetch a few public sample records to enrich (no auth needed).
+    uri: https://dummyjson.com/quotes?limit=3
+
+  - id: preview
+    type: io.kestra.plugin.core.log.Log
+    description: Log the fetched sample so the first run shows a real result.
+    message: |
+      Fetched sample data (HTTP {{ outputs.extract.code }}):
+      {{ outputs.extract.body }}
+
+  # --- ENABLE THE LLM (disabled until you add an API key) -------------
+  # Add your provider's API key as a secret, then remove `disabled: true`
+  # here AND on the `ai_result` task below to see the model's output.
+  #
+  # Using a different provider? Replace only the `provider:` block, e.g.
+  #   Anthropic: type: io.kestra.plugin.ai.provider.Anthropic
+  #              apiKey: "{{ secret('ANTHROPIC_API_KEY') }}"
+  #              modelName: claude-haiku-4-5
+  #   Gemini:    type: io.kestra.plugin.ai.provider.GoogleGemini
+  #              apiKey: "{{ secret('GEMINI_API_KEY') }}"
+  #              modelName: gemini-2.5-flash
+  # Full per-provider examples: https://kestra.io/blueprints?tags=AI
+  - id: enrich
+    type: io.kestra.plugin.ai.completion.ChatCompletion
+    provider:
+      type: io.kestra.plugin.ai.provider.OpenAI
+      apiKey: "{{ secret('OPENAI_API_KEY') }}"
+      modelName: gpt-4o-mini
+    messages:
+      - type: SYSTEM
+        content: You are a data assistant. Reply concisely.
+      - type: USER
+        content: |
+          Summarize the overall theme of these quotes in one sentence, then classify the sentiment of each as POSITIVE / NEUTRAL / NEGATIVE.
+          Data: {{ outputs.extract.body }}
+    disabled: true
+
+  - id: ai_result
+    type: io.kestra.plugin.core.log.Log
+    description: Log the model output. Enable this together with a provider above.
+    message: "AI enrichment:\n{{ outputs.enrich.textOutput }}"
+    disabled: true
+
+  # --- SEND A SLACK ALERT (optional) ---
+  - id: notify
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    messageText: "AI summary for {{ flow.namespace }}.{{ flow.id }}:\n{{ outputs.enrich.textOutput }}"
+    disabled: true
+
+# --- RUN THE FLOW AUTOMATICALLY (optional) ---
+triggers:
+  # Run via webhook.
+  - id: on_webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: aiZqjkJnKNgM4PsDUOExgRaJ
+    # URI: /api/v1/{tenant}/executions/webhook/{namespace}/{flowId}/aiZqjkJnKNgM4PsDUOExgRaJ
+    disabled: true
+
+  # AND / OR run on a schedule.
+  - id: every_morning
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 8 * * *" # Run every day at 8:00 AM
+    disabled: true
+
+extend:
+  shortDescription: Fetch a public dataset, log a preview, then plug in an LLM (OpenAI by default, or Anthropic or Gemini) to summarize and classify it.
+  title: "AI enrichment example: Getting started with Kestra"
+  metaTitle: Getting started AI enrichment flow with Kestra
+  metaDescription: A green-on-first-run AI example. Fetch public data and log a preview, then add an OpenAI (or Anthropic or Gemini) key to summarize and classify records.
+  description: |
+    A getting started AI enrichment flow that runs successfully on the very first execution with zero secrets. It fetches a few public sample records over HTTP and logs a preview, so a new user sees a real result immediately. To make it yours, add one LLM API key and enable a provider task to summarize the data and classify the sentiment of each record. It is the quickest way to see the fetch, then enrich with an LLM pattern working in Kestra before wiring in your own model and data.
+
+    ## How it works
+    1. The `extract` task (`io.kestra.plugin.core.http.Request`) fetches a small public sample of quotes from a public API. No authentication is required.
+    2. The `preview` task (`io.kestra.plugin.core.log.Log`) logs the HTTP status and body so the first run shows real data.
+    3. The optional `enrich` task (`io.kestra.plugin.ai.completion.ChatCompletion`) sends the data to your chosen LLM provider with a system and user prompt, asking for a one-sentence theme summary and a POSITIVE / NEUTRAL / NEGATIVE sentiment classification per record.
+    4. The optional `ai_result` task logs the model's `textOutput`, and the optional `notify` task posts it to Slack.
+
+    ## What you get
+    - A working AI-shaped run on the first click, with no keys to configure.
+    - A ready-to-enable `ChatCompletion` task you swap between OpenAI, Anthropic, and Gemini.
+    - A clear prompt that both summarizes and classifies in one call.
+    - Optional Slack alerting and webhook or schedule triggers.
+
+    ## Who it's for
+    - Teams evaluating Kestra for AI and LLM-backed data enrichment.
+    - Anyone new to Kestra who wants a green first run before adding a model key.
+    - Engineers building fetch, enrich, and notify pipelines over their own data.
+
+    ## Why orchestrate this with Kestra
+    Calling an LLM from a script is easy; operating that call is not. Kestra wraps the model call in a declarative pipeline with retries, full input and output logging, secret management for the API key, and the ability to trigger on a schedule or an event. Swapping OpenAI for Anthropic or Gemini is a single `provider` change, and the enriched output flows into downstream tasks (Slack, a warehouse, another flow) with tracked lineage a bare API call cannot give you.
+
+    ## Prerequisites
+    - A running Kestra instance with the AI plugin available.
+    - (Optional) An API key for OpenAI, Anthropic, or Google Gemini to enable enrichment.
+    - (Optional) A Slack incoming webhook for notifications.
+
+    ### Secrets
+    The default green path uses no secrets. Optional steps use:
+
+    - `OPENAI_API_KEY` (or `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`): the key for whichever provider you enable on the `enrich` task. OpenAI is the default.
+    - `SLACK_WEBHOOK`: Slack incoming webhook URL for the `notify` task.
+
+    ## Quick start
+    1. Add this flow to your Kestra instance and Execute it. It runs green with no setup.
+    2. To enrich with an LLM, add your provider key under Tenant > Secrets (namespace scoped).
+    3. Remove `disabled: true` from the `enrich` task and from `ai_result` to see the model output. The default provider is OpenAI; to use Anthropic or Gemini instead, swap the `provider` block (the flow shows the exact lines).
+    4. (Optional) Enable `notify` and a trigger to alert and automate.
+
+    ## How to extend
+    - Swap the provider from OpenAI to Anthropic (`io.kestra.plugin.ai.provider.Anthropic`) or Google Gemini (`io.kestra.plugin.ai.provider.GoogleGemini`) by replacing the `provider` block.
+    - Point `extract` at your own data source instead of the public sample.
+    - Use structured output to get typed JSON back instead of free text.
+    - Route the result to a warehouse, a ticket, or another flow.
+
+    ## Links
+    - [AI plugin](https://kestra.io/plugins/plugin-ai)
+    - [ChatCompletion task](https://kestra.io/plugins/plugin-ai/tasks/completion/io.kestra.plugin.ai.completion.chatcompletion)
+  tags:
+    - Getting Started
+    - AI
+  subTags:
+    - Agents & Structured Output
+  ee: false
+  demo: true

--- a/flows/getting-started-automation.yaml
+++ b/flows/getting-started-automation.yaml
@@ -1,0 +1,109 @@
+id: getting-started-automation
+namespace: tutorial
+
+description: |
+  # Automation example
+  Calls a public API and logs the response. Customize it to alert your tools or run on your own events.
+
+  Descriptions support **Markdown**.
+
+labels:
+  name: "Example: Automation"
+
+tasks:
+  - id: check
+    type: io.kestra.plugin.core.http.Request
+    description: Call a public endpoint and capture the response (no auth needed).
+    uri: https://dummyjson.com/products/1
+
+  - id: report
+    type: io.kestra.plugin.core.log.Log
+    description: Log the outcome so the first run shows a real result.
+    message: |
+      Called the API and got HTTP {{ outputs.check.code }}.
+      Response body:
+      {{ outputs.check.body }}
+
+  # --- SEND A SLACK ALERT (optional) ---
+  # Add a SLACK_WEBHOOK secret, then remove `disabled: true` to enable.
+  - id: notify
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    messageText: "Kestra Automation ran: API returned HTTP {{ outputs.check.code }} for flow {{ flow.namespace }}.{{ flow.id }} with ID {{ execution.id }}."
+    disabled: true
+
+# --- RUN THE FLOW AUTOMATICALLY (optional) ---
+triggers:
+  # Run via webhook.
+  - id: on_webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: auto4wjtkzwVGBM9yKnjm3yv8r
+    # URI: /api/v1/{tenant}/executions/webhook/{namespace}/{flowId}/auto4wjtkzwVGBM9yKnjm3yv8r
+    disabled: true
+
+  # AND / OR run on a schedule.
+  - id: every_morning
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 8 * * *" # Run every day at 8:00 AM
+    disabled: true
+
+extend:
+  shortDescription: Call a public API and log the response, then wire in a Slack alert and a webhook or schedule trigger to automate it.
+  title: "Automation example: Getting started with Kestra"
+  metaTitle: Getting started automation flow with Kestra
+  metaDescription: A green-on-first-run automation example. Call a public API and log the response, then add a Slack alert and a webhook or schedule trigger to run it on your events.
+  description: |
+    A getting started automation flow that runs successfully on the very first execution with zero secrets. It calls a public API and logs the response, so a new user sees a real result immediately. To make it yours, enable a Slack alert and a webhook or schedule trigger so the flow reacts to your own events and notifies your tools. It is the simplest way to see the call, then react pattern working in Kestra before connecting your own services.
+
+    ## How it works
+    1. The `check` task (`io.kestra.plugin.core.http.Request`) calls a public product API and captures the response. No authentication is required.
+    2. The `report` task (`io.kestra.plugin.core.log.Log`) logs the HTTP status code and body so the first run shows a real result.
+    3. The optional `notify` task (`io.kestra.plugin.slack.notifications.SlackIncomingWebhook`) posts the outcome to Slack once you enable it.
+    4. Optional `Webhook` and `Schedule` triggers let the flow run on an incoming event or on a cron.
+
+    ## What you get
+    - A working automation run on the first click, with no accounts or keys to configure.
+    - A realistic HTTP call and structured log you can adapt to any endpoint.
+    - Drop-in Slack alerting via `{{ secret('SLACK_WEBHOOK') }}`.
+    - Ready-to-enable webhook and schedule triggers.
+
+    ## Who it's for
+    - Ops and platform teams evaluating Kestra for automation and alerting.
+    - Anyone new to Kestra who wants a green first run before connecting services.
+    - Engineers building call, evaluate, and notify workflows on their own events.
+
+    ## Why orchestrate this with Kestra
+    A curl command can hit an API, but it cannot retry on failure, run on a schedule or an inbound webhook, keep secrets out of the code, or record every run for audit. Kestra models the whole automation as declarative YAML with triggers, retries, secret management, and full execution history. The same flow that logs a response today can, with a one-line change, alert Slack, open a ticket, or kick off a downstream pipeline.
+
+    ## Prerequisites
+    - A running Kestra instance.
+    - (Optional) A Slack incoming webhook for notifications.
+
+    ### Secrets
+    The default green path uses no secrets. Optional steps use:
+
+    - `SLACK_WEBHOOK`: Slack incoming webhook URL for the `notify` task.
+
+    ## Quick start
+    1. Add this flow to your Kestra instance and Execute it. It runs green with no setup.
+    2. To alert Slack, add a `SLACK_WEBHOOK` secret under Tenant > Secrets and remove `disabled: true` from the `notify` task.
+    3. To automate, remove `disabled: true` from the webhook or schedule trigger.
+
+    ## How to extend
+    - Point `check` at your own API and branch on the response with `If` conditions.
+    - Swap the Slack alert for email, Discord, PagerDuty, or a ticket.
+    - Trigger the flow from another system by POSTing to the webhook URL.
+    - Chain a downstream flow with `Subflow` once the check passes.
+
+    ## Links
+    - [HTTP Request task](https://kestra.io/plugins/core/tasks/io.kestra.plugin.core.http.request)
+    - [Slack plugin](https://kestra.io/plugins/plugin-notifications/tasks/slack/io.kestra.plugin.slack.notifications.slackincomingwebhook)
+  tags:
+    - Getting Started
+    - Core
+    - Business
+  subTags:
+    - Failure Alerting
+    - Realtime Events
+  ee: false
+  demo: true

--- a/flows/getting-started-elt-pipeline.yaml
+++ b/flows/getting-started-elt-pipeline.yaml
@@ -1,0 +1,127 @@
+id: getting-started-elt-pipeline
+namespace: tutorial
+
+description: |
+  # ELT pipeline example
+  Downloads a public CSV, aggregates it in embedded DuckDB, and logs the top products. Customize it to read from your own warehouse.
+
+  Descriptions support **Markdown**.
+
+labels:
+  name: "Example: ELT Pipeline"
+
+tasks:
+  - id: extract
+    type: io.kestra.plugin.core.http.Download
+    description: Fetch a public sample orders dataset (no auth needed).
+    uri: https://raw.githubusercontent.com/kestra-io/datasets/main/csv/orders.csv
+
+  - id: transform
+    type: io.kestra.plugin.jdbc.duckdb.Query
+    description: Load the CSV into embedded DuckDB and rank products by revenue.
+    communityExtensions: []  # skip the bundled 'ion' extension
+    inputFiles:
+      orders.csv: "{{ outputs.extract.uri }}"
+    sql: |
+      SELECT
+        product_id,
+        COUNT(*)             AS orders,
+        ROUND(SUM(total), 2) AS revenue,
+        ROUND(AVG(total), 2) AS avg_order_value
+      FROM read_csv_auto('orders.csv', header = true)
+      GROUP BY product_id
+      ORDER BY revenue DESC
+      LIMIT 10;
+    fetchType: FETCH
+
+  - id: report
+    type: io.kestra.plugin.core.log.Log
+    description: Log the headline numbers so the first run shows a real result.
+    message: |
+      Processed {{ outputs.transform.size }} products.
+      Top seller: product {{ outputs.transform.rows[0].product_id }}
+      with {{ outputs.transform.rows[0].orders }} orders and revenue {{ outputs.transform.rows[0].revenue }}.
+
+  # --- SEND A SLACK ALERT (optional) ---
+  # Add a SLACK_WEBHOOK secret, then remove `disabled: true` to enable.
+  - id: notify
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    messageText: "Kestra report ready: {{ outputs.transform.size }} products processed."
+    disabled: true
+
+# --- RUN THE FLOW AUTOMATICALLY (optional) ---
+triggers:
+  # Trigger via webhook (POST to the generated URL).
+  - id: on_webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: elt7wjtkzwM7yKnjm5yv3r # URI: /api/v1/{tenant}/executions/webhook/{namespace}/{flowId}/elt7wjtkzwM7yKnjm5yv3r
+    disabled: true
+
+  # OR run on a schedule.
+  - id: every_morning
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 8 * * *" # Run every day at 8:00 AM
+    disabled: true
+
+extend:
+  shortDescription: Download a public CSV, aggregate it in embedded DuckDB and log the top products, then swap in your own warehouse.
+  title: "ELT pipeline example: Getting started with Kestra"
+  metaTitle: Getting started ELT pipeline with DuckDB and Kestra
+  metaDescription: A green-on-first-run ELT example. Download a public CSV, rank products in embedded DuckDB, log the results, then swap in Snowflake, Postgres, BigQuery, or Redshift.
+  description: |
+    A getting started ELT pipeline that runs successfully on the very first execution with zero secrets. It downloads a public orders CSV, aggregates it in in-process DuckDB, and logs the top products by revenue. Once you have seen it run green, commented connector blocks let you point the same pipeline at your own warehouse (Snowflake, Postgres, BigQuery, or Redshift) and add a Slack alert. It is the fastest way to see the Extract, Load, Transform pattern working end to end in Kestra before wiring in real credentials.
+
+    ## How it works
+    1. The `extract` task (`io.kestra.plugin.core.http.Download`) fetches a public sample `orders.csv` from the Kestra datasets repository. No authentication is required.
+    2. The `transform` task (`io.kestra.plugin.jdbc.duckdb.Query`) loads that CSV into embedded DuckDB via `inputFiles` and runs a `GROUP BY product_id` aggregation, ranking products by revenue with `fetchType: FETCH`. `communityExtensions: []` skips a version-mismatched bundled extension so the query runs cleanly.
+    3. The `report` task (`io.kestra.plugin.core.log.Log`) logs the processed row count and the top seller so the first run shows a real, human-readable result.
+    4. The optional `notify` task posts a Slack summary once you enable it.
+
+    ## What you get
+    - A working ELT run on the first click, with no accounts or keys to configure.
+    - A realistic aggregation in embedded DuckDB you can read and adapt.
+    - Drop-in connector blocks for Snowflake, Postgres, BigQuery, and Redshift.
+    - Optional Slack alerting and webhook or schedule triggers.
+
+    ## Who it's for
+    - Data engineers evaluating Kestra for ELT and warehouse loading.
+    - Anyone new to Kestra who wants a green first run before adding credentials.
+    - Teams standardizing a reusable extract, transform, report skeleton.
+
+    ## Why orchestrate this with Kestra
+    A one-off script can download a CSV and run SQL, but it cannot version the pipeline, retry a failed load, track execution lineage, or swap the compute engine without a rewrite. Kestra models the whole flow as declarative YAML: the same `report` step reads `outputs.transform` no matter which warehouse produces it, so moving from DuckDB to Snowflake is a single task swap. You also get scheduling, event triggers, full logs, and replay out of the box.
+
+    ## Prerequisites
+    - A running Kestra instance with the DuckDB JDBC plugin available.
+    - (Optional) A warehouse and its credentials if you swap in your own connector.
+    - (Optional) A Slack incoming webhook for notifications.
+
+    ### Secrets
+    The default green path uses no secrets. Optional steps use:
+
+    - `SLACK_WEBHOOK`: Slack incoming webhook URL for the `notify` task.
+    - `SNOWFLAKE_PASSWORD` / `POSTGRES_PASSWORD` / `REDSHIFT_PASSWORD` / `BQ_SERVICE_ACCOUNT`: credentials for whichever warehouse connector you enable.
+
+    ## Quick start
+    1. Add this flow to your Kestra instance and Execute it. It runs green with no setup.
+    2. To read from your own warehouse, copy ONE connector block from the source comments and paste it OVER the DuckDB `transform` task (keep `id: transform` so `report` still works).
+    3. Set the matching secret under Tenant > Secrets.
+    4. (Optional) Remove `disabled: true` from `notify` and from a trigger to alert and automate.
+
+    ## How to extend
+    - Replace the sample CSV with your own source (S3, GCS, an API).
+    - Add data-quality checks (row counts, null checks) before `report`.
+    - Fan out to multiple warehouses or add a dbt transformation step.
+    - Enable the schedule or webhook trigger to run it automatically.
+
+    ## Links
+    - [DuckDB plugin](https://kestra.io/plugins/plugin-jdbc-duckdb)
+    - [HTTP Download task](https://kestra.io/plugins/core/tasks/io.kestra.plugin.core.http.download)
+  tags:
+    - Getting Started
+    - Data
+  subTags:
+    - ELT & Data Landing
+  ee: false
+  demo: true


### PR DESCRIPTION
Goal is to send them to early adopters to test, and in the future tailor blueprints to user's use case (based on information collected during cloud onboarding)

Adds three Getting Started blueprints converted from the Kestra Cloud onboarding example-flows: Example: ELT Pipeline (CSV to DuckDB), Example: Automation (API call plus optional Slack), and Example: AI Enrichment (fetch plus optional LLM).

Each runs green on the first execution with zero secrets: the default path uses only public data and core/DuckDB tasks, while every secret-requiring step (Slack, LLM, warehouse connectors) and all triggers ship disabled. Uses `namespace: tutorial` and `labels.name` to match the existing Getting Started set, with an "Example:" prefix to differentiate this onboarding set.

Tested on local Kestra EE 2.0: all three green paths SUCCESS (ELT with real DuckDB output), Slack path verified (webhook 200), AI enrich wiring verified.