### PR TITLE
Add LiveFaceSwap reference image preflight

### DIFF
--- a/flows/livefaceswap-reference-image-preflight.yaml
+++ b/flows/livefaceswap-reference-image-preflight.yaml
@@ -1,0 +1,328 @@
+id: livefaceswap-reference-image-preflight
+namespace: company.creative
+description: |
+  Download one authorized reference image, inspect JPG, PNG, or WebP file metadata,
+  and route the execution to a ready checklist or concrete preparation issues before
+  a private live face-swap test. This flow does not detect faces or run a face swap.
+
+inputs:
+  - id: reference_image_url
+    type: URI
+    displayName: Authorized reference image URL
+    description: Public HTTPS image URL that you control or are authorized to process.
+    defaults: https://r2.livefaceswap.ai/guides/live-face-swap-online/images/live-face-swap-online-cover-en.webp
+
+  - id: intended_effect
+    type: SELECT
+    displayName: Intended effect
+    description: Choose the LiveFaceSwap effect for which the reference is being prepared.
+    values:
+      - Face Swap
+      - Try-On
+      - Restyle
+    defaults: Face Swap
+
+  - id: authorization_confirmed
+    type: BOOLEAN
+    displayName: I own or have permission to use this image
+    description: Set false when ownership or permission has not been confirmed.
+    defaults: true
+
+tasks:
+  - id: inspect_reference_image
+    type: io.kestra.plugin.scripts.node.Script
+    description: Download the authorized image with a 10 MB streaming limit, detect supported file metadata, and emit a structured preflight result.
+    beforeCommands:
+      - npm install @kestra-io/libs
+    env:
+      REFERENCE_IMAGE_URL: "{{ inputs.reference_image_url }}"
+      INTENDED_EFFECT: "{{ inputs.intended_effect }}"
+      AUTHORIZATION_CONFIRMED: "{{ inputs.authorization_confirmed }}"
+    script: |
+      const MAX_BYTES = 10 * 1024 * 1024;
+      const MAX_REDIRECTS = 3;
+      
+      function ascii(bytes, start, end) {
+        return String.fromCharCode(...bytes.subarray(start, end));
+      }
+      
+      function uint16be(bytes, offset) {
+        return (bytes[offset] << 8) | bytes[offset + 1];
+      }
+      
+      function uint16le(bytes, offset) {
+        return bytes[offset] | (bytes[offset + 1] << 8);
+      }
+      
+      function uint24le(bytes, offset) {
+        return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+      }
+      
+      function uint32be(bytes, offset) {
+        return bytes[offset] * 0x1000000 + (bytes[offset + 1] << 16) + (bytes[offset + 2] << 8) + bytes[offset + 3];
+      }
+      
+      function uint32le(bytes, offset) {
+        return bytes[offset] + (bytes[offset + 1] << 8) + (bytes[offset + 2] << 16) + bytes[offset + 3] * 0x1000000;
+      }
+      
+      function detectImage(bytes) {
+        if (bytes.length >= 24 && ascii(bytes, 1, 4) === "PNG") {
+          return { format: "png", width: uint32be(bytes, 16), height: uint32be(bytes, 20) };
+        }
+      
+        if (bytes.length >= 30 && ascii(bytes, 0, 4) === "RIFF" && ascii(bytes, 8, 12) === "WEBP") {
+          const chunk = ascii(bytes, 12, 16);
+          if (chunk === "VP8X") {
+            return { format: "webp", width: 1 + uint24le(bytes, 24), height: 1 + uint24le(bytes, 27) };
+          }
+          if (chunk === "VP8 ") {
+            return { format: "webp", width: uint16le(bytes, 26) & 0x3fff, height: uint16le(bytes, 28) & 0x3fff };
+          }
+          if (chunk === "VP8L" && bytes.length >= 25 && bytes[20] === 0x2f) {
+            const bits = uint32le(bytes, 21);
+            return { format: "webp", width: 1 + (bits & 0x3fff), height: 1 + ((bits >>> 14) & 0x3fff) };
+          }
+        }
+      
+        if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+          let offset = 2;
+          const sofMarkers = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+          while (offset + 9 < bytes.length) {
+            if (bytes[offset] !== 0xff) {
+              offset += 1;
+              continue;
+            }
+            const marker = bytes[offset + 1];
+            if (sofMarkers.has(marker)) {
+              return { format: "jpeg", width: uint16be(bytes, offset + 7), height: uint16be(bytes, offset + 5) };
+            }
+            if (marker === 0xd8 || marker === 0xd9) {
+              offset += 2;
+              continue;
+            }
+            const length = uint16be(bytes, offset + 2);
+            if (length < 2) break;
+            offset += 2 + length;
+          }
+        }
+      
+        return { format: "unknown", width: null, height: null };
+      }
+      
+      function assertSafeHttpsUrl(rawUrl) {
+        const url = new URL(rawUrl);
+        if (url.protocol !== "https:") throw new Error("Reference image URL must use HTTPS.");
+        if (url.username || url.password) throw new Error("Reference image URL cannot contain credentials.");
+      
+        const host = url.hostname.toLowerCase().replace(/\.$/, "");
+        const blockedName = host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local") || host.endsWith(".internal");
+        const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+        const blockedIpv4 = ipv4 !== null && (() => {
+          const octets = ipv4.slice(1).map(Number);
+          if (octets.some((part) => part > 255)) return true;
+          const [a, b] = octets;
+          return a === 0 || a === 10 || a === 127 || a >= 224 || (a === 169 && b === 254) ||
+            (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+        })();
+        if (blockedName || blockedIpv4 || host.includes(":")) {
+          throw new Error("Reference image URL cannot target a local, private, or literal IPv6 host.");
+        }
+        return url;
+      }
+      
+      async function downloadBounded(rawUrl) {
+        let url = assertSafeHttpsUrl(rawUrl);
+        for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+          const response = await fetch(url, { redirect: "manual" });
+          if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.get("location");
+            if (!location || redirects === MAX_REDIRECTS) throw new Error("Too many or invalid redirects.");
+            url = assertSafeHttpsUrl(new URL(location, url).toString());
+            continue;
+          }
+          if (!response.ok) throw new Error(`Image download failed with HTTP ${response.status}.`);
+          const declaredLength = Number(response.headers.get("content-length") || "0");
+          if (Number.isFinite(declaredLength) && declaredLength > MAX_BYTES) return new Uint8Array(MAX_BYTES + 1);
+          if (!response.body) throw new Error("Image response did not include a body.");
+      
+          const chunks = [];
+          const reader = response.body.getReader();
+          let total = 0;
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            total += value.length;
+            if (total > MAX_BYTES) {
+              await reader.cancel();
+              return new Uint8Array(MAX_BYTES + 1);
+            }
+            chunks.push(value);
+          }
+          const bytes = new Uint8Array(total);
+          let offset = 0;
+          for (const chunk of chunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.length;
+          }
+          return bytes;
+        }
+        throw new Error("Image download did not complete.");
+      }
+      
+      function evaluateReferenceImage(bytes, intendedEffect, authorizationConfirmed) {
+        if (!authorizationConfirmed || bytes === null) {
+          return {
+            ready: false,
+            status: "needs_attention",
+            intendedEffect,
+            authorizationConfirmed: false,
+            detectedFormat: null,
+            width: null,
+            height: null,
+            sizeMb: null,
+            aspectRatio: null,
+            issues: ["Confirm that you own or have permission to use the reference image."],
+            manualChecks: [],
+            preflightScope: "File-level checks only; this workflow does not detect a face or run a face swap.",
+            tryLiveFaceSwap: "https://livefaceswap.ai",
+            setupGuide: "https://livefaceswap.ai/guides/live-face-swap-online",
+          };
+        }
+      
+        const image = detectImage(bytes);
+        const ratio = image.width && image.height ? image.width / image.height : null;
+        const issues = [];
+        if (!["jpeg", "png", "webp"].includes(image.format)) issues.push("Use a valid JPG, PNG, or WebP image.");
+        if (bytes.length > MAX_BYTES) issues.push("Keep the file at or below 10 MB for this preflight.");
+        if (image.width && image.height && Math.min(image.width, image.height) < 512) issues.push("Use at least 512 pixels on the shorter side.");
+        if (image.width && image.height && Math.max(image.width, image.height) > 8192) issues.push("Reduce the longest side to 8192 pixels or less.");
+        if (ratio && (ratio < 0.65 || ratio > 1.6)) issues.push("Use a portrait or moderately rectangular crop; avoid very wide or very tall images.");
+      
+        return {
+          ready: issues.length === 0,
+          status: issues.length === 0 ? "ready_for_private_test" : "needs_attention",
+          intendedEffect,
+          authorizationConfirmed: true,
+          detectedFormat: image.format,
+          width: image.width,
+          height: image.height,
+          sizeMb: Math.round((bytes.length / 1024 / 1024) * 100) / 100,
+          aspectRatio: ratio ? Math.round(ratio * 100) / 100 : null,
+          issues,
+          manualChecks: [
+            "Use one clearly visible subject that you own or are authorized to use.",
+            "Prefer even lighting, a clear face, and minimal occlusion.",
+            "Test privately before using the transformed camera in another app.",
+          ],
+          preflightScope: "File-level checks only; this workflow does not detect a face or run a face swap.",
+          tryLiveFaceSwap: "https://livefaceswap.ai",
+          setupGuide: "https://livefaceswap.ai/guides/live-face-swap-online",
+        };
+      }
+      
+      async function main(referenceImageUrl, intendedEffect, authorizationConfirmed) {
+        const allowedEffects = ["Face Swap", "Try-On", "Restyle"];
+        if (!allowedEffects.includes(intendedEffect)) throw new Error("Intended effect must be Face Swap, Try-On, or Restyle.");
+        if (!authorizationConfirmed) return evaluateReferenceImage(null, intendedEffect, false);
+        const bytes = await downloadBounded(referenceImageUrl);
+        return evaluateReferenceImage(bytes, intendedEffect, true);
+      }
+      
+      if (require.main === module) {
+        (async () => {
+          const result = await main(
+            process.env.REFERENCE_IMAGE_URL,
+            process.env.INTENDED_EFFECT || "Face Swap",
+            String(process.env.AUTHORIZATION_CONFIRMED).toLowerCase() === "true",
+          );
+          const { Kestra } = require("@kestra-io/libs");
+          Kestra.outputs(result);
+          console.log(JSON.stringify(result));
+        })().catch((error) => {
+          console.error(error instanceof Error ? error.message : String(error));
+          process.exitCode = 1;
+        });
+      }
+      
+      module.exports = { detectImage, evaluateReferenceImage, main };
+
+  - id: route_preflight_result
+    type: io.kestra.plugin.core.flow.If
+    description: Keep the pass and needs-attention paths visible in the execution graph.
+    condition: "{{ outputs.inspect_reference_image.vars.ready == true }}"
+    then:
+      - id: ready_for_private_test
+        type: io.kestra.plugin.core.debug.Return
+        description: Return a private-test status without claiming the image contains a usable face.
+        format: |
+          {"status":"ready_for_private_test","message":"The {{ outputs.inspect_reference_image.vars.detectedFormat | upper }} image passed the configurable file-level checks for {{ inputs.intended_effect }}.","workspace":"https://livefaceswap.ai","guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
+    else:
+      - id: needs_attention
+        type: io.kestra.plugin.core.debug.Return
+        description: Return the exact file-level or authorization issues that need attention.
+        format: |
+          {"status":"needs_attention","message":"The reference image needs attention before a private live face swap test.","issues":{{ outputs.inspect_reference_image.vars.issues | json }},"guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
+
+extend:
+  title: Preflight a Reference Image Before a Live Face Swap
+  shortDescription: Check an authorized JPG, PNG, or WebP reference and route it to a private-test checklist or concrete preparation issues.
+  metaTitle: Live Face Swap Reference Image Preflight with Kestra
+  metaDescription: Use Kestra to check an authorized reference image's format, size, dimensions, and crop before a private live face-swap test.
+  description: |
+    Reference-image intake is easy to treat as an informal handoff, which leads to
+    unsupported files, extreme crops, and missing permission checks being discovered
+    only after a live test has started. This Blueprint makes that preparation step
+    explicit and repeatable without pretending that file metadata can judge a face.
+
+    ## How it works
+
+    1. The flow accepts a public HTTPS image URL, the intended Face Swap, Try-On, or Restyle effect, and an explicit authorization confirmation.
+    2. **inspect_reference_image** streams at most 10 MB, rejects obvious local or private URL forms and unsafe redirects, detects JPG, PNG, or WebP dimensions, and applies configurable file-level limits.
+    3. **route_preflight_result** visibly branches on the emitted **ready** flag.
+    4. A passing file receives **ready_for_private_test** plus workspace and guide links; a failing input receives **needs_attention** plus its exact issues.
+
+    ## Inputs
+
+    - **reference_image_url**: a public HTTPS JPG, PNG, or WebP URL that you control or are authorized to process. The default is a project-owned sample.
+    - **intended_effect**: Face Swap, Try-On, or Restyle.
+    - **authorization_confirmed**: explicit ownership or permission confirmation. When false, the flow does not download the image.
+
+    ## Outputs
+
+    - **outputs.inspect_reference_image.vars.ready**: Boolean routing flag.
+    - **outputs.inspect_reference_image.vars.status**: **ready_for_private_test** or **needs_attention**.
+    - File format, dimensions, size, aspect ratio, issues, manual checks, and LiveFaceSwap next-step links are emitted as task variables.
+
+    ## Prerequisites and secrets
+
+    - A Kestra worker with outbound HTTPS access and permission to install **@kestra-io/libs** for the Node.js task.
+    - No API keys or Kestra secrets are required.
+    - Before accepting third-party images, configure execution-data retention, access controls, and egress policy. URL-form checks are not a substitute for network-level egress controls on a public endpoint.
+
+    ## Quick start
+
+    1. Import the YAML and run it once with the project-owned default image.
+    2. Run again with **authorization_confirmed** set to false to verify the needs-attention branch.
+    3. Replace the URL only with an image you control or are authorized to process.
+    4. Review the manual checks, then open https://livefaceswap.ai for a private test or follow https://livefaceswap.ai/guides/live-face-swap-online.
+
+    ## Scope boundary
+
+    This Blueprint performs file-level checks only. It does not detect a face, score
+    identity quality, upload the image to LiveFaceSwap, or run a face swap. A person
+    still needs to review subject visibility, lighting, framing, disclosure, and consent.
+
+    ## Links
+
+    - Node.js scripts plugin: https://kestra.io/plugins/plugin-script-node
+    - Core flow plugin: https://kestra.io/plugins/plugin-core
+    - LiveFaceSwap workspace: https://livefaceswap.ai
+    - LiveFaceSwap online setup guide: https://livefaceswap.ai/guides/live-face-swap-online
+  tags:
+    - Core
+    - AI
+  subTags:
+    - Image Processing
+  ee: false
+  demo: true

--- a/flows/livefaceswap-reference-image-preflight.yaml
+++ b/flows/livefaceswap-reference-image-preflight.yaml
@@ -1,9 +1,10 @@
 id: livefaceswap-reference-image-preflight
 namespace: company.creative
 description: |
-  Download one authorized reference image, inspect JPG, PNG, or WebP file metadata,
-  and route the execution to a ready checklist or concrete preparation issues before
-  a private live face-swap test. This flow does not detect faces or run a face swap.
+  Gate on permission, download one public HTTPS reference image, inspect its JPG,
+  PNG, or WebP metadata, and route it to a ready checklist or concrete preparation
+  issues before a private live face-swap test. This flow does not detect faces or
+  run a face swap.
 
 inputs:
   - id: reference_image_url
@@ -29,246 +30,184 @@ inputs:
     defaults: true
 
 tasks:
-  - id: inspect_reference_image
-    type: io.kestra.plugin.scripts.node.Script
-    description: Download the authorized image with a 10 MB streaming limit, detect supported file metadata, and emit a structured preflight result.
-    beforeCommands:
-      - npm install @kestra-io/libs
-    env:
-      REFERENCE_IMAGE_URL: "{{ inputs.reference_image_url }}"
-      INTENDED_EFFECT: "{{ inputs.intended_effect }}"
-      AUTHORIZATION_CONFIRMED: "{{ inputs.authorization_confirmed }}"
-    script: |
-      const MAX_BYTES = 10 * 1024 * 1024;
-      const MAX_REDIRECTS = 3;
-      
-      function ascii(bytes, start, end) {
-        return String.fromCharCode(...bytes.subarray(start, end));
-      }
-      
-      function uint16be(bytes, offset) {
-        return (bytes[offset] << 8) | bytes[offset + 1];
-      }
-      
-      function uint16le(bytes, offset) {
-        return bytes[offset] | (bytes[offset + 1] << 8);
-      }
-      
-      function uint24le(bytes, offset) {
-        return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
-      }
-      
-      function uint32be(bytes, offset) {
-        return bytes[offset] * 0x1000000 + (bytes[offset + 1] << 16) + (bytes[offset + 2] << 8) + bytes[offset + 3];
-      }
-      
-      function uint32le(bytes, offset) {
-        return bytes[offset] + (bytes[offset + 1] << 8) + (bytes[offset + 2] << 16) + bytes[offset + 3] * 0x1000000;
-      }
-      
-      function detectImage(bytes) {
-        if (bytes.length >= 24 && ascii(bytes, 1, 4) === "PNG") {
-          return { format: "png", width: uint32be(bytes, 16), height: uint32be(bytes, 20) };
-        }
-      
-        if (bytes.length >= 30 && ascii(bytes, 0, 4) === "RIFF" && ascii(bytes, 8, 12) === "WEBP") {
-          const chunk = ascii(bytes, 12, 16);
-          if (chunk === "VP8X") {
-            return { format: "webp", width: 1 + uint24le(bytes, 24), height: 1 + uint24le(bytes, 27) };
-          }
-          if (chunk === "VP8 ") {
-            return { format: "webp", width: uint16le(bytes, 26) & 0x3fff, height: uint16le(bytes, 28) & 0x3fff };
-          }
-          if (chunk === "VP8L" && bytes.length >= 25 && bytes[20] === 0x2f) {
-            const bits = uint32le(bytes, 21);
-            return { format: "webp", width: 1 + (bits & 0x3fff), height: 1 + ((bits >>> 14) & 0x3fff) };
-          }
-        }
-      
-        if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
-          let offset = 2;
-          const sofMarkers = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
-          while (offset + 9 < bytes.length) {
-            if (bytes[offset] !== 0xff) {
-              offset += 1;
-              continue;
-            }
-            const marker = bytes[offset + 1];
-            if (sofMarkers.has(marker)) {
-              return { format: "jpeg", width: uint16be(bytes, offset + 7), height: uint16be(bytes, offset + 5) };
-            }
-            if (marker === 0xd8 || marker === 0xd9) {
-              offset += 2;
-              continue;
-            }
-            const length = uint16be(bytes, offset + 2);
-            if (length < 2) break;
-            offset += 2 + length;
-          }
-        }
-      
-        return { format: "unknown", width: null, height: null };
-      }
-      
-      function assertSafeHttpsUrl(rawUrl) {
-        const url = new URL(rawUrl);
-        if (url.protocol !== "https:") throw new Error("Reference image URL must use HTTPS.");
-        if (url.username || url.password) throw new Error("Reference image URL cannot contain credentials.");
-      
-        const host = url.hostname.toLowerCase().replace(/\.$/, "");
-        const blockedName = host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local") || host.endsWith(".internal");
-        const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-        const blockedIpv4 = ipv4 !== null && (() => {
-          const octets = ipv4.slice(1).map(Number);
-          if (octets.some((part) => part > 255)) return true;
-          const [a, b] = octets;
-          return a === 0 || a === 10 || a === 127 || a >= 224 || (a === 169 && b === 254) ||
-            (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
-        })();
-        if (blockedName || blockedIpv4 || host.includes(":")) {
-          throw new Error("Reference image URL cannot target a local, private, or literal IPv6 host.");
-        }
-        return url;
-      }
-      
-      async function downloadBounded(rawUrl) {
-        let url = assertSafeHttpsUrl(rawUrl);
-        for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
-          const response = await fetch(url, { redirect: "manual" });
-          if (response.status >= 300 && response.status < 400) {
-            const location = response.headers.get("location");
-            if (!location || redirects === MAX_REDIRECTS) throw new Error("Too many or invalid redirects.");
-            url = assertSafeHttpsUrl(new URL(location, url).toString());
-            continue;
-          }
-          if (!response.ok) throw new Error(`Image download failed with HTTP ${response.status}.`);
-          const declaredLength = Number(response.headers.get("content-length") || "0");
-          if (Number.isFinite(declaredLength) && declaredLength > MAX_BYTES) return new Uint8Array(MAX_BYTES + 1);
-          if (!response.body) throw new Error("Image response did not include a body.");
-      
-          const chunks = [];
-          const reader = response.body.getReader();
-          let total = 0;
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            total += value.length;
-            if (total > MAX_BYTES) {
-              await reader.cancel();
-              return new Uint8Array(MAX_BYTES + 1);
-            }
-            chunks.push(value);
-          }
-          const bytes = new Uint8Array(total);
-          let offset = 0;
-          for (const chunk of chunks) {
-            bytes.set(chunk, offset);
-            offset += chunk.length;
-          }
-          return bytes;
-        }
-        throw new Error("Image download did not complete.");
-      }
-      
-      function evaluateReferenceImage(bytes, intendedEffect, authorizationConfirmed) {
-        if (!authorizationConfirmed || bytes === null) {
-          return {
-            ready: false,
-            status: "needs_attention",
-            intendedEffect,
-            authorizationConfirmed: false,
-            detectedFormat: null,
-            width: null,
-            height: null,
-            sizeMb: null,
-            aspectRatio: null,
-            issues: ["Confirm that you own or have permission to use the reference image."],
-            manualChecks: [],
-            preflightScope: "File-level checks only; this workflow does not detect a face or run a face swap.",
-            tryLiveFaceSwap: "https://livefaceswap.ai",
-            setupGuide: "https://livefaceswap.ai/guides/live-face-swap-online",
-          };
-        }
-      
-        const image = detectImage(bytes);
-        const ratio = image.width && image.height ? image.width / image.height : null;
-        const issues = [];
-        if (!["jpeg", "png", "webp"].includes(image.format)) issues.push("Use a valid JPG, PNG, or WebP image.");
-        if (bytes.length > MAX_BYTES) issues.push("Keep the file at or below 10 MB for this preflight.");
-        if (image.width && image.height && Math.min(image.width, image.height) < 512) issues.push("Use at least 512 pixels on the shorter side.");
-        if (image.width && image.height && Math.max(image.width, image.height) > 8192) issues.push("Reduce the longest side to 8192 pixels or less.");
-        if (ratio && (ratio < 0.65 || ratio > 1.6)) issues.push("Use a portrait or moderately rectangular crop; avoid very wide or very tall images.");
-      
-        return {
-          ready: issues.length === 0,
-          status: issues.length === 0 ? "ready_for_private_test" : "needs_attention",
-          intendedEffect,
-          authorizationConfirmed: true,
-          detectedFormat: image.format,
-          width: image.width,
-          height: image.height,
-          sizeMb: Math.round((bytes.length / 1024 / 1024) * 100) / 100,
-          aspectRatio: ratio ? Math.round(ratio * 100) / 100 : null,
-          issues,
-          manualChecks: [
-            "Use one clearly visible subject that you own or are authorized to use.",
-            "Prefer even lighting, a clear face, and minimal occlusion.",
-            "Test privately before using the transformed camera in another app.",
-          ],
-          preflightScope: "File-level checks only; this workflow does not detect a face or run a face swap.",
-          tryLiveFaceSwap: "https://livefaceswap.ai",
-          setupGuide: "https://livefaceswap.ai/guides/live-face-swap-online",
-        };
-      }
-      
-      async function main(referenceImageUrl, intendedEffect, authorizationConfirmed) {
-        const allowedEffects = ["Face Swap", "Try-On", "Restyle"];
-        if (!allowedEffects.includes(intendedEffect)) throw new Error("Intended effect must be Face Swap, Try-On, or Restyle.");
-        if (!authorizationConfirmed) return evaluateReferenceImage(null, intendedEffect, false);
-        const bytes = await downloadBounded(referenceImageUrl);
-        return evaluateReferenceImage(bytes, intendedEffect, true);
-      }
-      
-      if (require.main === module) {
-        (async () => {
-          const result = await main(
-            process.env.REFERENCE_IMAGE_URL,
-            process.env.INTENDED_EFFECT || "Face Swap",
-            String(process.env.AUTHORIZATION_CONFIRMED).toLowerCase() === "true",
-          );
-          const { Kestra } = require("@kestra-io/libs");
-          Kestra.outputs(result);
-          console.log(JSON.stringify(result));
-        })().catch((error) => {
-          console.error(error instanceof Error ? error.message : String(error));
-          process.exitCode = 1;
-        });
-      }
-      
-      module.exports = { detectImage, evaluateReferenceImage, main };
-
-  - id: route_preflight_result
+  - id: authorization_gate
     type: io.kestra.plugin.core.flow.If
-    description: Keep the pass and needs-attention paths visible in the execution graph.
-    condition: "{{ outputs.inspect_reference_image.vars.ready == true }}"
+    description: Prevent any network request until ownership or permission is explicitly confirmed.
+    condition: "{{ inputs.authorization_confirmed }}"
     then:
-      - id: ready_for_private_test
-        type: io.kestra.plugin.core.debug.Return
-        description: Return a private-test status without claiming the image contains a usable face.
-        format: |
-          {"status":"ready_for_private_test","message":"The {{ outputs.inspect_reference_image.vars.detectedFormat | upper }} image passed the configurable file-level checks for {{ inputs.intended_effect }}.","workspace":"https://livefaceswap.ai","guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
+      - id: validate_reference_url
+        type: io.kestra.plugin.scripts.node.Script
+        description: Apply a focused URL-form check before Kestra makes the HTTP request.
+        beforeCommands:
+          - npm install @kestra-io/libs
+        env:
+          REFERENCE_IMAGE_URL: "{{ inputs.reference_image_url }}"
+        script: |
+          const Kestra = require("@kestra-io/libs");
+
+          function validateReferenceUrl(rawUrl) {
+            try {
+              const url = new URL(rawUrl);
+              if (url.protocol !== "https:") return "Reference image URL must use HTTPS.";
+              if (url.username || url.password) return "Reference image URL cannot contain credentials.";
+
+              const host = url.hostname.toLowerCase().replace(/\.$/, "");
+              if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local") || host.endsWith(".internal")) {
+                return "Reference image URL cannot target a local hostname.";
+              }
+              if (host.includes(":")) return "Reference image URL cannot use a literal IPv6 host.";
+
+              const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+              if (ipv4) {
+                const octets = ipv4.slice(1).map(Number);
+                const [a, b] = octets;
+                const blocked = octets.some((part) => part > 255) || a === 0 || a === 10 || a === 127 || a >= 224 ||
+                  (a === 100 && b >= 64 && b <= 127) || (a === 169 && b === 254) ||
+                  (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) ||
+                  (a === 198 && (b === 18 || b === 19));
+                if (blocked) return "Reference image URL cannot target a local, private, or reserved IPv4 host.";
+              }
+              return null;
+            } catch {
+              return "Reference image URL is invalid.";
+            }
+          }
+
+          const issue = validateReferenceUrl(process.env.REFERENCE_IMAGE_URL);
+          Kestra.outputs({ safe: issue === null, issue });
+
+      - id: url_safety_gate
+        type: io.kestra.plugin.core.flow.If
+        description: Download only URLs that pass the explicit public-HTTPS form check.
+        condition: "{{ outputs.validate_reference_url.vars.safe }}"
+        then:
+          - id: download_reference_image
+            type: io.kestra.plugin.core.http.Download
+            description: Use Kestra's certified HTTP task to download at most 10 MB; redirects are disabled so they cannot bypass the URL gate.
+            uri: "{{ inputs.reference_image_url }}"
+            saveAs: reference-image.bin
+            timeout: PT1M
+            options:
+              followRedirects: false
+              maxContentLength: 10485760
+              readTimeout: PT30S
+
+          - id: inspect_image_metadata
+            type: io.kestra.plugin.scripts.node.Script
+            description: Read only the downloaded file and emit format, dimensions, size, ratio, and preparation issues.
+            beforeCommands:
+              - npm install @kestra-io/libs
+            inputFiles:
+              reference-image.bin: "{{ outputs.download_reference_image.uri }}"
+            env:
+              INTENDED_EFFECT: "{{ inputs.intended_effect }}"
+            script: |
+              const fs = require("fs");
+              const Kestra = require("@kestra-io/libs");
+              const MAX_BYTES = 10 * 1024 * 1024;
+
+              function ascii(bytes, start, end) {
+                return bytes.subarray(start, end).toString("ascii");
+              }
+
+              function uint24le(bytes, offset) {
+                return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+              }
+
+              function detectImage(bytes) {
+                if (bytes.length >= 24 && bytes[0] === 0x89 && ascii(bytes, 1, 4) === "PNG") {
+                  return { format: "png", width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
+                }
+
+                if (bytes.length >= 30 && ascii(bytes, 0, 4) === "RIFF" && ascii(bytes, 8, 12) === "WEBP") {
+                  const chunk = ascii(bytes, 12, 16);
+                  if (chunk === "VP8X") return { format: "webp", width: 1 + uint24le(bytes, 24), height: 1 + uint24le(bytes, 27) };
+                  if (chunk === "VP8 ") return { format: "webp", width: bytes.readUInt16LE(26) & 0x3fff, height: bytes.readUInt16LE(28) & 0x3fff };
+                  if (chunk === "VP8L" && bytes.length >= 25 && bytes[20] === 0x2f) {
+                    const bits = bytes.readUInt32LE(21);
+                    return { format: "webp", width: 1 + (bits & 0x3fff), height: 1 + ((bits >>> 14) & 0x3fff) };
+                  }
+                }
+
+                if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+                  let offset = 2;
+                  const sof = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+                  while (offset + 9 < bytes.length) {
+                    if (bytes[offset] !== 0xff) {
+                      offset += 1;
+                      continue;
+                    }
+                    const marker = bytes[offset + 1];
+                    if (sof.has(marker)) return { format: "jpeg", width: bytes.readUInt16BE(offset + 7), height: bytes.readUInt16BE(offset + 5) };
+                    if (marker === 0xd8 || marker === 0xd9) {
+                      offset += 2;
+                      continue;
+                    }
+                    const length = bytes.readUInt16BE(offset + 2);
+                    if (length < 2) break;
+                    offset += 2 + length;
+                  }
+                }
+
+                return { format: "unknown", width: null, height: null };
+              }
+
+              const bytes = fs.readFileSync("reference-image.bin");
+              const image = detectImage(bytes);
+              const ratio = image.width && image.height ? image.width / image.height : null;
+              const issues = [];
+              if (!["jpeg", "png", "webp"].includes(image.format)) issues.push("Use a valid JPG, PNG, or WebP image.");
+              if (bytes.length > MAX_BYTES) issues.push("Keep the file at or below 10 MB for this preflight.");
+              if (image.width && image.height && Math.min(image.width, image.height) < 512) issues.push("Use at least 512 pixels on the shorter side.");
+              if (image.width && image.height && Math.max(image.width, image.height) > 8192) issues.push("Reduce the longest side to 8192 pixels or less.");
+              if (ratio && (ratio < 0.65 || ratio > 1.6)) issues.push("Use a portrait or moderately rectangular crop; avoid very wide or very tall images.");
+
+              Kestra.outputs({
+                ready: issues.length === 0,
+                status: issues.length === 0 ? "ready_for_private_test" : "needs_attention",
+                intendedEffect: process.env.INTENDED_EFFECT,
+                detectedFormat: image.format,
+                width: image.width,
+                height: image.height,
+                sizeMb: Math.round((bytes.length / 1024 / 1024) * 100) / 100,
+                aspectRatio: ratio ? Math.round(ratio * 100) / 100 : null,
+                issues,
+              });
+
+          - id: route_preflight_result
+            type: io.kestra.plugin.core.flow.If
+            description: Keep the pass and needs-attention paths visible in the execution graph.
+            condition: "{{ outputs.inspect_image_metadata.vars.ready }}"
+            then:
+              - id: ready_for_private_test
+                type: io.kestra.plugin.core.debug.Return
+                description: Return a private-test status without claiming that the image contains a usable face.
+                format: |
+                  {"status":"ready_for_private_test","message":"The {{ outputs.inspect_image_metadata.vars.detectedFormat | upper }} image passed the file-level checks for {{ inputs.intended_effect }}.","manualChecks":["Use one clearly visible subject that you own or are authorized to use.","Prefer even lighting, a clear face, and minimal occlusion.","Test privately before using the transformed camera in another app."],"workspace":"https://livefaceswap.ai","guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
+            else:
+              - id: image_needs_attention
+                type: io.kestra.plugin.core.debug.Return
+                description: Return the exact file-level issues that need attention.
+                format: |
+                  {"status":"needs_attention","message":"The reference image needs attention before a private live face swap test.","issues":{{ outputs.inspect_image_metadata.vars.issues | json }},"guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
+        else:
+          - id: unsafe_url_needs_attention
+            type: io.kestra.plugin.core.debug.Return
+            description: Explain why no request was made for the supplied URL.
+            format: |
+              {"status":"needs_attention","message":{{ outputs.validate_reference_url.vars.issue | json }},"guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
     else:
-      - id: needs_attention
+      - id: authorization_needs_attention
         type: io.kestra.plugin.core.debug.Return
-        description: Return the exact file-level or authorization issues that need attention.
+        description: Stop before any URL validation or download when permission is not confirmed.
         format: |
-          {"status":"needs_attention","message":"The reference image needs attention before a private live face swap test.","issues":{{ outputs.inspect_reference_image.vars.issues | json }},"guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
+          {"status":"needs_attention","message":"Confirm that you own or have permission to use the reference image.","workspace":"https://livefaceswap.ai","guide":"https://livefaceswap.ai/guides/live-face-swap-online"}
 
 extend:
   title: Preflight a Reference Image Before a Live Face Swap
-  shortDescription: Check an authorized JPG, PNG, or WebP reference and route it to a private-test checklist or concrete preparation issues.
+  shortDescription: Check permission, URL safety, and JPG, PNG, or WebP file metadata before a private face-swap test.
   metaTitle: Live Face Swap Reference Image Preflight with Kestra
-  metaDescription: Use Kestra to check an authorized reference image's format, size, dimensions, and crop before a private live face-swap test.
+  metaDescription: Use Kestra to check an authorized image's URL, format, size, dimensions, and crop before a private live face-swap test.
   description: |
     Reference-image intake is easy to treat as an informal handoff, which leads to
     unsupported files, extreme crops, and missing permission checks being discovered
@@ -277,35 +216,39 @@ extend:
 
     ## How it works
 
-    1. The flow accepts a public HTTPS image URL, the intended Face Swap, Try-On, or Restyle effect, and an explicit authorization confirmation.
-    2. **inspect_reference_image** streams at most 10 MB, rejects obvious local or private URL forms and unsafe redirects, detects JPG, PNG, or WebP dimensions, and applies configurable file-level limits.
-    3. **route_preflight_result** visibly branches on the emitted **ready** flag.
-    4. A passing file receives **ready_for_private_test** plus workspace and guide links; a failing input receives **needs_attention** plus its exact issues.
+    1. `authorization_gate` stops the flow before any network request unless ownership or permission is confirmed.
+    2. `validate_reference_url` checks for HTTPS, embedded credentials, local names, and literal private or reserved hosts.
+    3. `url_safety_gate` allows only a passing URL into `download_reference_image`, the certified Kestra HTTP Download task. The task caps content at 10 MB and disables redirects so a redirect cannot bypass the URL gate.
+    4. `inspect_image_metadata` receives the stored file through `inputFiles`, detects JPG, PNG, or WebP dimensions, and applies file-level size, dimension, and crop checks.
+    5. `route_preflight_result` returns either a private-test checklist or the concrete issues to fix.
 
     ## Inputs
 
-    - **reference_image_url**: a public HTTPS JPG, PNG, or WebP URL that you control or are authorized to process. The default is a project-owned sample.
-    - **intended_effect**: Face Swap, Try-On, or Restyle.
-    - **authorization_confirmed**: explicit ownership or permission confirmation. When false, the flow does not download the image.
+    - `reference_image_url` (URI): a public HTTPS JPG, PNG, or WebP URL that you control or are authorized to process. The default is a project-owned sample.
+    - `intended_effect` (SELECT): `Face Swap`, `Try-On`, or `Restyle`; defaults to `Face Swap`.
+    - `authorization_confirmed` (BOOLEAN): explicit ownership or permission confirmation. When false, the flow makes no network request.
 
     ## Outputs
 
-    - **outputs.inspect_reference_image.vars.ready**: Boolean routing flag.
-    - **outputs.inspect_reference_image.vars.status**: **ready_for_private_test** or **needs_attention**.
-    - File format, dimensions, size, aspect ratio, issues, manual checks, and LiveFaceSwap next-step links are emitted as task variables.
+    - `outputs.validate_reference_url.vars.safe`: Boolean URL routing flag.
+    - `outputs.download_reference_image.uri`: image file in Kestra internal storage.
+    - `outputs.inspect_image_metadata.vars.ready`: Boolean result routing flag.
+    - `outputs.inspect_image_metadata.vars.status`: `ready_for_private_test` or `needs_attention`.
+    - The metadata task also emits format, dimensions, size, aspect ratio, and issue strings.
 
     ## Prerequisites and secrets
 
-    - A Kestra worker with outbound HTTPS access and permission to install **@kestra-io/libs** for the Node.js task.
+    - A Kestra worker with outbound HTTPS access and permission to install `@kestra-io/libs` for the two focused Node.js tasks.
     - No API keys or Kestra secrets are required.
-    - Before accepting third-party images, configure execution-data retention, access controls, and egress policy. URL-form checks are not a substitute for network-level egress controls on a public endpoint.
+    - Before accepting third-party images, configure execution-data retention, access controls, DNS and egress policy. URL-form checks are not a substitute for network-level egress controls.
 
     ## Quick start
 
-    1. Import the YAML and run it once with the project-owned default image.
-    2. Run again with **authorization_confirmed** set to false to verify the needs-attention branch.
-    3. Replace the URL only with an image you control or are authorized to process.
-    4. Review the manual checks, then open https://livefaceswap.ai for a private test or follow https://livefaceswap.ai/guides/live-face-swap-online.
+    1. Import the YAML and run it with the project-owned default image.
+    2. Run with `authorization_confirmed` set to false and confirm the download task is skipped.
+    3. Try a private or non-HTTPS URL and confirm the HTTP task is skipped.
+    4. Replace the URL only with an image you control or are authorized to process.
+    5. Review the manual checks, then open https://livefaceswap.ai for a private test or follow https://livefaceswap.ai/guides/live-face-swap-online.
 
     ## Scope boundary
 
@@ -315,6 +258,7 @@ extend:
 
     ## Links
 
+    - HTTP Download task: https://kestra.io/plugins/core/http/io.kestra.plugin.core.http.download
     - Node.js scripts plugin: https://kestra.io/plugins/plugin-script-node
     - Core flow plugin: https://kestra.io/plugins/plugin-core
     - LiveFaceSwap workspace: https://livefaceswap.ai


### PR DESCRIPTION
## What this Blueprint does

Adds `livefaceswap-reference-image-preflight`, a no-secret workflow that checks an authorized JPG, PNG, or WebP reference image before a private live face-swap test. It validates permission confirmation, bounded download size, format, dimensions, and aspect ratio, then routes to a ready or needs-attention result.

LiveFaceSwap AI is our product. The Blueprint links to our workspace and setup guide as the optional next step. The workflow itself does not call a LiveFaceSwap API, detect faces, score identity quality, or perform a face swap.

## Validation

- [x] `id` matches the hyphen-case filename and `namespace` is set.
- [x] Multiple tasks are fully defined and include descriptions.
- [x] `extend` contains a human title, rich description, `metaDescription` (119 characters), allowed tags, `ee`, and `demo`.
- [x] Prerequisites, inputs, outputs, links, scope boundaries, and common egress/retention cautions are documented.
- [x] No credentials or secrets are required or hardcoded.
- [x] Focused local checks cover the project-owned WebP, a very wide image, authorization disabled, and a private-network URL.

## Expected outputs

- `outputs.inspect_image_metadata.vars.status`: `ready_for_private_test` or `needs_attention`
- `outputs.inspect_image_metadata.vars.issues`: concrete file-level or authorization issues
- `outputs.inspect_image_metadata.vars.detectedFormat`, `width`, `height`, `sizeMb`, and `aspectRatio`

The default image is owned by the contributing project and can be used to run the demo without credentials.
