### PR TITLE
feat: add Magic Hour AI image generation blueprint

### DIFF
--- a/flows/magic-hour-ai-image-generation.yaml
+++ b/flows/magic-hour-ai-image-generation.yaml
@@ -1,0 +1,150 @@
+id: magic-hour-ai-image-generation
+namespace: company.team
+description: |
+  Create an AI image with Magic Hour, retain the returned project ID, poll that same
+  project until it completes or fails, and expose the final download URL without
+  accidentally starting duplicate billable renders.
+
+inputs:
+  - id: prompt
+    type: STRING
+    displayName: Image prompt
+    description: A detailed description of the image to generate.
+    required: true
+    defaults: A ceramic coffee mug on a warm studio background, premium product photography
+
+  - id: aspect_ratio
+    type: SELECT
+    displayName: Aspect ratio
+    description: Output image aspect ratio supported by the Magic Hour image generator.
+    required: true
+    values:
+      - "1:1"
+      - "16:9"
+      - "9:16"
+    defaults: "1:1"
+
+tasks:
+  - id: create_image
+    type: io.kestra.plugin.core.http.Request
+    description: Start exactly one Magic Hour image project and retain its ID for every later poll.
+    uri: https://api.magichour.ai/v1/ai-image-generator
+    method: POST
+    contentType: application/json
+    headers:
+      Authorization: "Bearer {{ secret('MAGIC_HOUR_API_KEY') }}"
+      Accept: application/json
+    body: |
+      {
+        "name": "Kestra image {{ execution.id }}",
+        "image_count": 1,
+        "model": "default",
+        "aspect_ratio": "{{ inputs.aspect_ratio }}",
+        "resolution": "auto",
+        "style": {
+          "prompt": {{ inputs.prompt | toJson }},
+          "tool": "general"
+        }
+      }
+
+  - id: wait_for_image
+    type: io.kestra.plugin.core.flow.LoopUntil
+    description: Poll the original project every 10 seconds until Magic Hour reports complete or error.
+    condition: "{{ ['complete', 'error'] contains (outputs.poll_project.body | jq('.status') | first) }}"
+    checkFrequency:
+      interval: PT10S
+      maxDuration: PT10M
+    failOnMaxReached: true
+    tasks:
+      - id: poll_project
+        type: io.kestra.plugin.core.http.Request
+        description: Retrieve status and downloads for the project created by create_image.
+        uri: "https://api.magichour.ai/v1/image-projects/{{ outputs.create_image.body | jq('.id') | first }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ secret('MAGIC_HOUR_API_KEY') }}"
+          Accept: application/json
+
+  - id: fail_render_error
+    type: io.kestra.plugin.core.flow.If
+    description: Fail explicitly when Magic Hour reaches a terminal error state.
+    condition: "{{ (outputs.poll_project.body | jq('.status') | first) == 'error' }}"
+    then:
+      - id: report_render_error
+        type: io.kestra.plugin.core.execution.Fail
+        errorMessage: "Magic Hour project {{ outputs.create_image.body | jq('.id') | first }} failed: {{ outputs.poll_project.body | jq('.error') | first }}"
+
+  - id: report_completed_image
+    type: io.kestra.plugin.core.log.Log
+    description: Report the completed project ID and exact expiring download URL.
+    message: |
+      Magic Hour project: {{ outputs.create_image.body | jq('.id') | first }}
+      Download URL: {{ outputs.poll_project.body | jq('.downloads[0].url') | first }}
+      Expires at: {{ outputs.poll_project.body | jq('.downloads[0].expires_at') | first }}
+
+extend:
+  title: Generate an AI Image with Magic Hour and Wait for Completion
+  metaTitle: Magic Hour AI Image Generation Workflow with Kestra
+  shortDescription: Create a Magic Hour AI image, poll one project to completion, and return its exact download URL without duplicate renders.
+  metaDescription: Generate AI images with Magic Hour in Kestra, safely poll one project to completion, and retrieve the final download URL.
+  description: |
+    Turn an image prompt into a completed Magic Hour asset from a reusable Kestra workflow. The flow starts one billable image project, stores its project ID, polls that same project until it reaches a terminal state, and reports the exact download URL and expiration time. Reusing the original ID is essential: starting a new project after an ambiguous timeout can create duplicate renders and extra API spend.
+
+    ## How it works
+
+    1. `create_image` (`io.kestra.plugin.core.http.Request`) sends the prompt and aspect ratio to `POST /v1/ai-image-generator`. It requests one image with Magic Hour's default model and stores the returned project ID in `{{ outputs.create_image.body | jq('.id') | first }}`.
+    2. `wait_for_image` (`io.kestra.plugin.core.flow.LoopUntil`) calls `GET /v1/image-projects/{id}` every 10 seconds. It stops only when the same project reaches `complete` or `error`, with a 10-minute maximum duration.
+    3. `fail_render_error` converts Magic Hour's terminal `error` state into a failed Kestra execution that includes the API error details.
+    4. `report_completed_image` logs the project ID, exact download URL, and expiration timestamp from the completed project.
+
+    ## Prerequisites
+
+    - A running Kestra instance with outbound HTTPS access to `api.magichour.ai`.
+    - A Magic Hour account with API credits and an API key from the developer dashboard.
+
+    ### Secrets
+
+    - `MAGIC_HOUR_API_KEY`: authenticates the create and project-status requests. Each Kestra user should supply their own key; never place it directly in the flow YAML.
+
+    ## Inputs
+
+    - `prompt` (STRING): required image description. The default demonstrates product photography.
+    - `aspect_ratio` (SELECT): `1:1`, `16:9`, or `9:16`; defaults to `1:1`.
+
+    ## Expected outputs
+
+    - Project ID: `{{ outputs.create_image.body | jq('.id') | first }}`.
+    - Final URL: `{{ outputs.poll_project.body | jq('.downloads[0].url') | first }}`.
+    - URL expiration: `{{ outputs.poll_project.body | jq('.downloads[0].expires_at') | first }}`.
+
+    Download URLs expire. Copy a completed asset to durable storage in a downstream task when the workflow needs to retain it.
+
+    ## Quick start
+
+    1. Create a Magic Hour API key at `https://magichour.ai/developer` and save it as the Kestra secret `MAGIC_HOUR_API_KEY`.
+    2. Import this flow and choose a prompt and aspect ratio.
+    3. Execute the flow. The create request consumes Magic Hour API credits; the status polls do not create more projects.
+    4. Open `report_completed_image` to copy the final URL before it expires.
+
+    ## How to extend
+
+    - Add `io.kestra.plugin.core.http.Download` and an S3, GCS, or Azure Blob upload task to persist the completed image.
+    - Trigger the flow from an approved campaign brief, product catalog row, or webhook.
+    - Replace the create endpoint and body with Magic Hour image-to-video or lip-sync while keeping the same one-project polling pattern.
+    - Add an editorial approval task before distributing the generated asset.
+
+    ## Links
+
+    - [Magic Hour API documentation](https://docs.magichour.ai/)
+    - [Magic Hour image generator API](https://docs.magichour.ai/api-reference/image-projects/ai-image-generator)
+    - [Magic Hour developer dashboard](https://magichour.ai/developer)
+    - [Kestra core HTTP plugin](https://kestra.io/plugins/plugin-core/http/io.kestra.plugin.core.http.Request)
+    - [Kestra LoopUntil task](https://kestra.io/plugins/core/flow/io.kestra.plugin.core.flow.LoopUntil)
+  tags:
+    - AI
+    - Business
+  subTags:
+    - Content Generation
+    - API Integrations
+  ee: false
+  demo: false


### PR DESCRIPTION
## What this adds

Adds a ready-to-import Magic Hour AI image generation Blueprint. It starts exactly one billable project, retains its ID, polls that same project to `complete` or `error`, fails clearly on render errors, and reports the exact expiring download URL.

This gives Kestra users a useful AI media workflow using the core HTTP and LoopUntil tasks, with no new plugin or SDK dependency.

## Required metadata

- [x] `id` matches the filename (hyphen-case) and `namespace` is set.
- [x] `tasks` are fully defined; non-obvious behavior has task descriptions.
- [x] `extend` includes title, rich description, prerequisites, quick start, expected outputs, a 121-character `metaDescription`, tags, `ee`, and `demo`.

## Documentation checklist

- [x] Prerequisites and the `MAGIC_HOUR_API_KEY` secret are documented without a value.
- [x] Inputs, allowed values, defaults, and primary output expressions are documented.
- [x] Magic Hour API and Kestra task documentation links are included and return HTTP 200.

## Best practices

- [x] No hardcoded credentials; the flow uses `{{ secret('MAGIC_HOUR_API_KEY') }}`.
- [x] Notes cover API credit consumption, timeout behavior, URL expiration, and durable storage.

## Validation

- Parsed independently with PyYAML and Ruby YAML.
- Confirmed ID equals filename, allowed tags are used, task count is four, and `metaDescription` is under 160 characters.
- `git diff --check` passes.
- Sent the documented create payload with an intentionally invalid token; production returned HTTP 401, confirming the authentication boundary without creating a billable project.

A paid image render was not run because no reviewer API credential was available. Each user supplies their own Magic Hour key when importing the Blueprint.

Disclosure: this vendor contribution is submitted on behalf of Magic Hour and was created with an AI coding agent.
