### PR TITLE
feat: add an Agent Guild preflight A2A blueprint

### DIFF
--- a/flows/agent-guild-preflight-a2a-handoff.yaml
+++ b/flows/agent-guild-preflight-a2a-handoff.yaml
@@ -1,0 +1,178 @@
+id: agent-guild-preflight-a2a-handoff
+namespace: company.ai
+description: Preserve endpoint evidence and apply an operator policy before an A2A message.
+
+variables:
+  delegation_enabled: false
+
+inputs:
+  - id: endpoint
+    type: STRING
+    description: Public HTTPS A2A 0.3 JSON-RPC endpoint; no credentials, query, fragment, port, or sensitive path data.
+    validator: '(?i)^https://(?=.{1,2048}$)(?!(?:[^/]*\.)?(?:localhost|local|internal|test|invalid)(?:/|$))(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}(?:/[A-Za-z0-9._~/-]*)?$'
+  - id: message
+    type: STRING
+    description: Text to send only after the configured policy accepts the preflight evidence.
+    validator: '(?s)^.{1,8192}$'
+
+tasks:
+  - id: preflight
+    type: io.kestra.plugin.core.http.Request
+    description: Send only the public endpoint URL to Agent Guild for a free live inspection.
+    uri: https://agent-guild-5d5r.onrender.com/preflight
+    method: GET
+    params:
+      url: "{{ inputs.endpoint }}"
+    timeout: PT45S
+    options:
+      followRedirects: false
+      allowFailed: true
+      timeout:
+        connectTimeout: PT10S
+        readIdleTimeout: PT30S
+
+  - id: preserve_evidence
+    type: io.kestra.plugin.core.storage.Write
+    description: Keep the exact response body before parsing or applying the policy, including error bodies.
+    content: "{{ outputs.preflight.body }}"
+    extension: .json
+
+  - id: policy_gate
+    type: io.kestra.plugin.core.flow.If
+    description: Require explicit operator enablement and matching evidence with no failed or unknown checks.
+    condition: >-
+      {{ vars.delegation_enabled == true
+         and outputs.preflight.code == 200
+         and fromJson(outputs.preflight.body).target == inputs.endpoint
+         and fromJson(outputs.preflight.body).verdict == 'no_failed_checks'
+         and (outputs.preflight.body | jq('type == "object" and (.failed | type == "array" and length == 0) and (.unknowns | type == "array" and length == 0) and (.checks | type == "array" and length > 0 and all(.[]; type == "object" and (.check | type == "string" and length > 0) and .status == "proven")) and (.checks | map(.check) | contains(["endpoint_reachable", "protocol_handshake"])) and (.checks | map(.check) | length == (unique | length))') | first) == true }}
+    then:
+      - id: handoff
+        type: io.kestra.plugin.core.http.Request
+        description: Send one A2A 0.3 JSON-RPC message to the exact endpoint that was inspected; no automatic retry.
+        uri: "{{ inputs.endpoint }}"
+        method: POST
+        contentType: application/json
+        body: >-
+          {{ {"jsonrpc": "2.0", "id": execution.id,
+              "method": "message/send",
+              "params": {"message": {"kind": "message", "role": "user",
+                "messageId": execution.id,
+                "parts": [{"kind": "text", "text": inputs.message}]}}} | toJson }}
+        timeout: PT45S
+        options:
+          followRedirects: false
+          allowFailed: true
+          timeout:
+            connectTimeout: PT10S
+            readIdleTimeout: PT30S
+
+      - id: preserve_handoff
+        type: io.kestra.plugin.core.storage.Write
+        description: Preserve the remote response, including asynchronous task state or error details.
+        content: "{{ outputs.handoff.body }}"
+        extension: .json
+
+      - id: require_a2a_response
+        type: io.kestra.plugin.core.execution.Assert
+        description: Fail on HTTP or JSON-RPC errors without retrying the delegated work.
+        conditions:
+          - "{{ outputs.handoff.code == 200 }}"
+          - "{{ fromJson(outputs.handoff.body).jsonrpc == '2.0' }}"
+          - "{{ fromJson(outputs.handoff.body).id == execution.id }}"
+          - >-
+            {{ (outputs.handoff.body | jq('has("error") == false and (.result | type == "object" and ((.kind == "task" and (.id | type == "string" and length > 0) and (.contextId | type == "string" and length > 0) and (.status.state == "submitted" or .status.state == "working" or .status.state == "input-required" or .status.state == "auth-required" or .status.state == "completed")) or (.kind == "message" and .role == "agent" and (.messageId | type == "string" and length > 0) and (.parts | type == "array" and length > 0))))') | first) == true }}
+        errorMessage: Inspect handoff response and stored evidence; acceptance of a message is not completion of its task.
+    else:
+      - id: stop_before_delegation
+        type: io.kestra.plugin.core.execution.Fail
+        errorMessage: Operator policy blocked delegation. Inspect preflight.code, preflight.body, and preserve_evidence.uri for the verdict, failed checks, and unknowns.
+
+outputs:
+  - id: preflight_body
+    type: STRING
+    value: "{{ outputs.preflight.body | default('') }}"
+  - id: evidence_uri
+    type: STRING
+    value: "{{ outputs.preserve_evidence.uri | default('') }}"
+  - id: handoff_response
+    type: STRING
+    value: "{{ outputs.handoff.body | default('') }}"
+
+extend:
+  title: Inspect an agent endpoint before an A2A handoff
+  description: |
+    Keep a live endpoint inspection alongside an A2A delegation decision. This
+    blueprint uses only Kestra 2.0 core tasks: HTTP Request, storage Write,
+    If, Assert, and Fail. It needs no Agent Guild account, API key, wallet,
+    model provider, script runner, or additional plugin.
+
+    ## Before you run
+
+    Choose a public HTTPS endpoint that supports the A2A 0.3 JSON-RPC
+    `message/send` method without authentication. This recipe deliberately
+    targets that version; it does not negotiate a different A2A version or
+    discover another URL from an agent card. The endpoint must contain no
+    credentials, query string, fragment, explicit port, or sensitive path data.
+    The conservative validator also excludes IP literals and local-only names.
+    It does not perform DNS classification. The URL is sent to Agent Guild's
+    hosted service for inspection; the message stays in Kestra until handoff.
+
+    The `endpoint` input is required. The `message` input is required and limited
+    to 8192 characters. No secrets are used. Do not put secrets in either input.
+
+    ## Configure the operator policy
+
+    `variables.delegation_enabled` defaults to false. The deploying operator
+    may set it to true after deciding this policy is appropriate: HTTP 200,
+    a matching target, `no_failed_checks`, and actual empty `failed` and
+    `unknowns` arrays, and a nonempty `checks` array whose named entries all
+    have status `proven`. Check names must be unique and include the mandatory
+    `endpoint_reachable` and `protocol_handshake` checks. This rejects
+    contradictory or missing check details.
+    Keep this setting in the reviewed flow definition;
+    do not turn it into an agent-controlled input. Failed checks, caution,
+    unknowns, malformed evidence, and a disabled policy stop before handoff.
+    A clean result with unknown checks is blocked too. This strict policy
+    may block many endpoints; it is a deliberate application rule.
+
+    ## Run and inspect
+
+    1. Import the flow and supply the endpoint and message.
+    2. Review the policy setting before enabling delegation.
+    3. Inspect `outputs.preflight.body` for the complete response, including
+       `verdict`, `failed`, and `unknowns`; `outputs.preserve_evidence.uri`
+       stores the exact body even when the policy blocks the flow.
+    4. An accepted branch sends one A2A request. Inspect
+       `outputs.handoff.body` and `outputs.preserve_handoff.uri` for the result.
+       A returned task may still be working or require input; this flow does
+       not poll it or claim completion. Failed runs retain task outputs even
+       when final flow outputs are not produced.
+
+    Preflight is free. Delegated work is governed by the remote endpoint's
+    terms; this flow sends no payment credentials and never pays a 402.
+    Redirects are not followed. Requests have connection, idle-read, and total
+    task timeouts. Core Request also enforces its native output-size limit.
+    There is no automatic retry of the A2A message: an ambiguous timeout can
+    mean work was accepted remotely, so inspect it before any manual retry.
+
+    This policy uses observed evidence, not a guarantee of safety or future
+    performance. Returned text is data, not execution instructions. Agent
+    Guild also supports signed Agent Passports as a separate service;
+    fetching one is not signature verification or proof that this endpoint
+    controls its subject identity. This blueprint does not fetch passports,
+    verify signatures, register agents, call paid trust operations, or expose
+    the complete Guild MCP tool catalogue to a model.
+
+    ## Links
+
+    - [Agent Guild source and API](https://github.com/AgentTanuki/agent-guild)
+    - [Kestra HTTP Request](https://kestra.io/plugins/core/http/io.kestra.plugin.core.http.request)
+    - [Kestra If](https://kestra.io/plugins/core/flow/io.kestra.plugin.core.flow.if)
+    - [A2A 0.3 message/send](https://a2a-protocol.org/v0.3.0/specification/#71-messagesend)
+  tags:
+    - AI
+    - Core
+  ee: false
+  demo: false
+  metaDescription: Preserve Agent Guild preflight evidence and apply an explicit operator policy before an A2A message, using only Kestra core tasks.


### PR DESCRIPTION
Adds a Kestra 2.0 blueprint that preserves endpoint preflight evidence before sending an A2A 0.3 message. The deploying operator enables the policy in the flow definition; it requires a matching target, no failed or unknown checks, and both mandatory endpoint checks with consistent evidence. Blocked runs retain the raw inspection response. Accepted runs retain the remote reply and distinguish message acceptance from completion of an asynchronous task.

The blueprint uses five built-in core task types and the free Agent Guild preflight route. It requires no additional plugin, model provider, Guild account or wallet. It follows this repository's blueprint contribution invitation and includes prerequisites, input/output documentation, API links, recognized tags and the required catalog metadata. Delegation and automatic demo execution are disabled by default.

Validation: all 38 cases passed on the official Kestra 2.0.0 standalone runtime with local HTTP/A2A fixtures, including accepted message/task responses, blocked policy and malformed evidence, transport failures, invalid inputs and rejected remote responses. Every rejected preflight/policy/input made zero handoffs. All 32 response-body storage/readback checks passed. Native flow parsing/topology and metadata checks passed, as did the tag check across all 691 blueprint files. No production Guild, model or payment call was made.

The runtime tests use the underlying flow after removing the catalog-only `extend` block. The recipe deliberately targets A2A 0.3 and validates a minimum response envelope; no browser UI import or live third-party interoperability test is claimed. The submitted source SHA-256 is `c7ccf4e4c689f1624a542735a2d470cbd58202f217a0d7033f4a4a513d5c79e5`.
